### PR TITLE
fix: allow unknown values in storage_name validation for module variables

### DIFF
--- a/synology/provider/virtualization/guest_resource.go
+++ b/synology/provider/virtualization/guest_resource.go
@@ -484,8 +484,9 @@ func (f *GuestResource) ValidateConfig(
 
 	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
 
-	if (data.StorageID.IsNull() || data.StorageID.IsUnknown()) &&
-		(data.StorageName.IsNull() || data.StorageName.IsUnknown()) {
+	// Only validate if both values are explicitly null (not set)
+	// Allow unknown values to pass validation as they will be resolved during planning
+	if data.StorageID.IsNull() && data.StorageName.IsNull() {
 		resp.Diagnostics.AddError(
 			"At least one of storage_id or storage_name must be set",
 			"At least one of storage_id or storage_name must be set",

--- a/synology/provider/virtualization/guest_resource_test.go
+++ b/synology/provider/virtualization/guest_resource_test.go
@@ -1,14 +1,115 @@
 package virtualization_test
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
 	r "github.com/hashicorp/terraform-plugin-testing/helper/resource"
 	"github.com/synology-community/terraform-provider-synology/synology/acctest"
+	"github.com/synology-community/terraform-provider-synology/synology/provider/virtualization"
 )
 
 type GuestResource struct{}
+
+// TestGuestResourceValidateConfig_ModuleVariables tests the validation logic
+// when storage_name is provided via module variables (unknown during validation)
+func TestGuestResourceValidateConfig_ModuleVariables(t *testing.T) {
+	testCases := []struct {
+		name        string
+		storageID   types.String
+		storageName types.String
+		expectError bool
+		description string
+	}{
+		{
+			name:        "both_null_should_error",
+			storageID:   types.StringNull(),
+			storageName: types.StringNull(),
+			expectError: true,
+			description: "Both storage_id and storage_name are null",
+		},
+		{
+			name:        "storage_name_unknown_should_not_error",
+			storageID:   types.StringNull(),
+			storageName: types.StringUnknown(), // This simulates a module variable
+			expectError: false,
+			description: "storage_name is unknown (from module variable) - should pass validation",
+		},
+		{
+			name:        "storage_id_unknown_should_not_error",
+			storageID:   types.StringUnknown(), // This simulates a module variable
+			storageName: types.StringNull(),
+			expectError: false,
+			description: "storage_id is unknown (from module variable) - should pass validation",
+		},
+		{
+			name:        "both_unknown_should_not_error",
+			storageID:   types.StringUnknown(),
+			storageName: types.StringUnknown(),
+			expectError: false,
+			description: "Both are unknown (from module variables) - should pass validation",
+		},
+		{
+			name:        "storage_name_set_should_not_error",
+			storageID:   types.StringNull(),
+			storageName: types.StringValue("default"),
+			expectError: false,
+			description: "storage_name has a value - should pass validation",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create a GuestResource instance
+			guestResource := &virtualization.GuestResource{}
+
+			// Create a mock config with the test values
+			model := virtualization.GuestResourceModel{
+				Name:        types.StringValue("test-vm"),
+				StorageID:   tc.storageID,
+				StorageName: tc.storageName,
+				VcpuNum:     types.Int64Value(4),
+				VramSize:    types.Int64Value(4096),
+			}
+
+			// Create a tfsdk.Config from the model
+			schema, diags := guestResource.Schema(context.Background(), resource.SchemaRequest{}, &resource.SchemaResponse{})
+			if diags.HasError() {
+				t.Fatalf("Failed to get schema: %v", diags)
+			}
+
+			config := tfsdk.Config{
+				Schema: schema.Schema,
+			}
+
+			// Set the config values
+			diags = config.Set(context.Background(), model)
+			if diags.HasError() {
+				t.Fatalf("Failed to set config: %v", diags)
+			}
+
+			// Test ValidateConfig
+			req := resource.ValidateConfigRequest{
+				Config: config,
+			}
+			resp := &resource.ValidateConfigResponse{}
+
+			guestResource.ValidateConfig(context.Background(), req, resp)
+
+			// Check if the result matches expectations
+			hasError := resp.Diagnostics.HasError()
+			if tc.expectError && !hasError {
+				t.Errorf("Expected validation error for %s, but got none", tc.description)
+			} else if !tc.expectError && hasError {
+				t.Errorf("Expected no validation error for %s, but got: %v", tc.description, resp.Diagnostics.Errors())
+			}
+		})
+	}
+}
 
 func TestAccGuestResource_basic(t *testing.T) {
 	testCases := []struct {


### PR DESCRIPTION
- Fixes validation error when storage_name is set via module variables
- Changed validation logic to only fail when both storage_id and storage_name are explicitly null
- Allows unknown values (from module variables) to pass validation as they are resolved during planning phase

Fixes #68