### PR TITLE
Use the correct model for disks

### DIFF
--- a/synology/provider/virtualization/guest_data_source.go
+++ b/synology/provider/virtualization/guest_data_source.go
@@ -175,7 +175,7 @@ func (m *GuestDataSourceModel) FromGuest(v *virtualization.Guest) error {
 
 		disks = append(disks, disk)
 	}
-	if diskst, err := types.SetValue(VNicDataModel{}.ModelType(), disks); err == nil {
+	if diskst, err := types.SetValue(VDiskDataModel{}.ModelType(), disks); err == nil {
 		m.Disks = diskst
 	}
 


### PR DESCRIPTION
This PR fixes a bug where the `FromGuest` function was using an incorrect model to marshal the
`virtualization_guest` API read operation `Disks` object into a `VNicDataModel` rather than a `VDiskDataModel`
