### PR TITLE
fix(core_task): map cron schedules onto DSM's real scheduler model

### DIFF
--- a/docs/resources/core_task.md
+++ b/docs/resources/core_task.md
@@ -22,7 +22,7 @@ A Generic API Resource for making calls to the Synology DSM API.
 ### Optional
 
 - `run` (Boolean) Whether to run the task after creation.
-- `schedule` (String) Schedule expressed in cron.
+- `schedule` (String) Schedule expressed in cron, mapped onto DSM's scheduler: a fixed time (`17 3 * * *`) becomes a daily task, a day-of-week restriction (`17 3 * * 1-5`) becomes a weekly one, and an even interval (`*/15 * * * *`, `30 */6 * * *`) becomes DSM's repeat_min/repeat_hour. Schedules DSM cannot represent are rejected rather than silently mis-stored: day-of-month or month restrictions, bounded windows (`0 9-17 * * *`), and unevenly spaced lists (`0,7,30`).
 - `script` (String) Script content to run in the task.
 - `service` (String) Systemctl service to change state.
 - `when` (String) When to run the task. Valid values are `apply` and `destroy`.

--- a/synology/provider/core/task_resource.go
+++ b/synology/provider/core/task_resource.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"regexp"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
@@ -244,8 +245,14 @@ func (p *TaskResource) Schema(
 				Required:            true,
 			},
 			"schedule": schema.StringAttribute{
-				MarkdownDescription: "Schedule expressed in cron.",
-				Optional:            true,
+				MarkdownDescription: "Schedule expressed in cron, mapped onto DSM's scheduler: a fixed time " +
+					"(`17 3 * * *`) becomes a daily task, a day-of-week restriction " +
+					"(`17 3 * * 1-5`) becomes a weekly one, and an even interval (`*/15 * * * *`, " +
+					"`30 */6 * * *`) becomes DSM's repeat_min/repeat_hour. Schedules DSM cannot " +
+					"represent are rejected rather than silently mis-stored: day-of-month or month " +
+					"restrictions, bounded windows (`0 9-17 * * *`), and unevenly spaced lists " +
+					"(`0,7,30`).",
+				Optional: true,
 				Validators: []validator.String{
 					stringvalidator.RegexMatches(
 						regexp.MustCompile(
@@ -366,6 +373,104 @@ func newTaskSchedule() core.TaskSchedule {
 	}
 }
 
+// DSM's Task Scheduler expresses a schedule with a small set of fields whose
+// meanings were established by probing a live DSM 7.4:
+//
+//	repeat_date 1001                  daily at hour:minute
+//	repeat_date 1002 + week_day       weekly, on those weekdays, at hour:minute
+//	repeat_hour N  (hour = start)     every N hours, beginning at hour:minute
+//	repeat_min  N  (minute = start)   every N minutes, beginning at :minute
+//
+// Two properties of that model drive everything below. First, hour and minute
+// are LITERAL values -- DSM writes them straight into /etc/crontab. Second,
+// DSM validates none of it: a schedule of hour=128 is stored verbatim and
+// yields a task that is created, reported as enabled, and can never fire. All
+// validation therefore has to happen here.
+const (
+	dsmRepeatDaily  = 1001
+	dsmRepeatWeekly = 1002
+
+	// util.ParseStandard sets the top bit of a field that contained "*".
+	cronStarBit = uint64(1) << 63
+)
+
+// cronFieldValues returns the values a cron bitfield encodes, ascending.
+func cronFieldValues(mask int64, max int64) []int64 {
+	u := uint64(mask) &^ cronStarBit
+	values := make([]int64, 0, 8)
+	for i := int64(0); i <= max; i++ {
+		if u&(uint64(1)<<uint(i)) != 0 {
+			values = append(values, i)
+		}
+	}
+	return values
+}
+
+// cronField is one parsed cron field expressed in DSM's terms: a starting
+// value, plus an interval when the field repeats.
+type cronField struct {
+	start int64
+	step  int64 // 0 when the field names a single point in time
+}
+
+// classifyCronField maps one cron field onto DSM's model.
+//
+// A single value ("17") becomes a start with no step. An even progression that
+// runs to the end of the field ("*", "*/15", "5/15") becomes a start plus a
+// step, which DSM stores as repeat_min/repeat_hour. Anything else -- a list
+// ("0,30"), a bounded range ("9-17"), or a stepped range that stops early
+// ("0-45/15") -- selects a set of times DSM has no way to represent, so it is
+// rejected rather than approximated.
+func classifyCronField(mask int64, max int64, name string) (cronField, error) {
+	values := cronFieldValues(mask, max)
+
+	switch len(values) {
+	case 0:
+		// Unset: how the "@every ..." descriptors arrive, carrying only the
+		// repeat_* counters.
+		return cronField{}, nil
+	case 1:
+		return cronField{start: values[0]}, nil
+	}
+
+	step := values[1] - values[0]
+	for i := 2; i < len(values); i++ {
+		if values[i]-values[i-1] != step {
+			return cronField{}, fmt.Errorf(
+				"schedule field %s: %q selects an uneven set of values; DSM can express a "+
+					"single %s or an even interval, not an arbitrary list",
+				name, cronFieldString(values), name)
+		}
+	}
+
+	// An interval must run to the end of the field. A progression that stops
+	// early is a bounded window ("0-45/15" fires at :00 :15 :30 :45 and then
+	// waits), and DSM has no field for the window.
+	if last := values[len(values)-1]; last+step <= max {
+		return cronField{}, fmt.Errorf(
+			"schedule field %s: %q stops at %d rather than repeating through %d; DSM "+
+				"repeats an interval for the whole %s range",
+			name, cronFieldString(values), last, max, name)
+	}
+
+	return cronField{start: values[0], step: step}, nil
+}
+
+// cronFieldString renders values for an error message without dragging in a
+// formatting dependency.
+func cronFieldString(values []int64) string {
+	parts := make([]string, 0, len(values))
+	for _, v := range values {
+		parts = append(parts, strconv.FormatInt(v, 10))
+	}
+	return strings.Join(parts, ",")
+}
+
+// weekDayString renders DSM's week_day field.
+func weekDayString(values []int64) string {
+	return cronFieldString(values)
+}
+
 func parseSchedule(c string) (res core.TaskSchedule, err error) {
 	if c == "" {
 		return
@@ -378,15 +483,79 @@ func parseSchedule(c string) (res core.TaskSchedule, err error) {
 
 	t := newTaskSchedule()
 
-	t.Minute = s.Minute
-	t.Hour = s.Hour
-	t.RepeatDate = s.RepeatDate
-	t.RepeatHour = s.RepeatHour
-	t.RepeatMin = s.RepeatMin
-
-	if t.DateType == 0 && t.RepeatDate == 0 {
-		t.RepeatDate = 1001
+	// "@every ..." sets only the repeat_* counters and leaves every cron field
+	// empty; pass it through untouched.
+	if s.Minute == 0 && s.Hour == 0 && s.Dom == 0 && s.Month == 0 && s.Dow == 0 {
+		t.RepeatDate = s.RepeatDate
+		t.RepeatHour = s.RepeatHour
+		t.RepeatMin = s.RepeatMin
+		if t.DateType == 0 && t.RepeatDate == 0 {
+			t.RepeatDate = dsmRepeatDaily
+		}
+		return t, nil
 	}
+
+	// DSM schedules recur daily or weekly. Restricting the day of the month or
+	// the month has no representation, and silently ignoring the restriction
+	// would run the task far more often than asked.
+	if dom := cronFieldValues(s.Dom, 31); len(dom) != 31 {
+		return res, fmt.Errorf(
+			"schedule: day-of-month restrictions are not supported; DSM repeats daily or "+
+				"weekly, so %q cannot be expressed", c)
+	}
+	if months := cronFieldValues(s.Month, 12); len(months) != 12 {
+		return res, fmt.Errorf(
+			"schedule: month restrictions are not supported; DSM repeats daily or weekly, "+
+				"so %q cannot be expressed", c)
+	}
+
+	minute, err := classifyCronField(s.Minute, 59, "minute")
+	if err != nil {
+		return res, err
+	}
+	hour, err := classifyCronField(s.Hour, 23, "hour")
+	if err != nil {
+		return res, err
+	}
+
+	// DSM carries one interval per task, in either repeat_min or repeat_hour.
+	// A minute interval repeats across the whole day, so the hour field has to
+	// be unrestricted -- "every 15 minutes, but only during hour 3" has no
+	// representation. An unrestricted hour is not itself an interval here: it
+	// is the absence of a restriction.
+	hourUnrestricted := len(cronFieldValues(s.Hour, 23)) == 24
+
+	switch {
+	case minute.step != 0:
+		if !hourUnrestricted {
+			return res, fmt.Errorf(
+				"schedule: %q repeats every %d minutes but also restricts the hour; DSM "+
+					"repeats a minute interval across the whole day",
+				c, minute.step)
+		}
+		t.Minute = minute.start
+		t.Hour = 0
+		t.RepeatMin = minute.step
+	case hour.step != 0:
+		t.Minute = minute.start
+		t.Hour = hour.start
+		t.RepeatHour = hour.step
+	default:
+		t.Minute = minute.start
+		t.Hour = hour.start
+	}
+
+	// Day of week: all seven days is DSM's daily mode; any subset is its weekly
+	// mode. The provider used to discard this field entirely, which turned
+	// "0 3 * * 1" into a task that ran every morning instead of on Mondays.
+	weekDays := cronFieldValues(s.Dow, 6)
+	if len(weekDays) == 7 {
+		t.RepeatDate = dsmRepeatDaily
+	} else {
+		t.RepeatDate = dsmRepeatWeekly
+		t.WeekDay = weekDayString(weekDays)
+	}
+
 	return t, nil
 }
 

--- a/synology/provider/core/task_schedule_test.go
+++ b/synology/provider/core/task_schedule_test.go
@@ -1,0 +1,334 @@
+package core
+
+import "testing"
+
+// The mappings asserted here were established against a live DSM 7.4 by
+// creating disabled probe tasks and reading back what DSM stored and when it
+// said the task would next run:
+//
+//	repeat_date 1001                 daily at hour:minute
+//	repeat_date 1002 + week_day      weekly on those days at hour:minute
+//	repeat_hour N (hour = start)     every N hours from hour:minute
+//	repeat_min  N (minute = start)   every N minutes from :minute
+//
+// DSM validates none of these values -- hour=128 is accepted and stored, and
+// the task simply never fires -- so every case below is the provider's
+// responsibility, not the device's.
+
+func TestParseScheduleDailyUsesLiteralHourAndMinute(t *testing.T) {
+	for _, tc := range []struct {
+		spec   string
+		minute int64
+		hour   int64
+	}{
+		{"17 3 * * *", 17, 3},
+		{"0 7 * * *", 0, 7},
+		{"30 2 * * *", 30, 2},
+		{"0 0 * * *", 0, 0},     // bit 0 in both fields
+		{"59 23 * * *", 59, 23}, // upper bound of both fields
+	} {
+		t.Run(tc.spec, func(t *testing.T) {
+			got, err := parseSchedule(tc.spec)
+			if err != nil {
+				t.Fatalf("parseSchedule(%q) returned error: %v", tc.spec, err)
+			}
+			if got.Minute != tc.minute {
+				t.Errorf("minute = %d, want %d (a bitfield leaked through if this is 1<<%d)",
+					got.Minute, tc.minute, tc.minute)
+			}
+			if got.Hour != tc.hour {
+				t.Errorf("hour = %d, want %d (a bitfield leaked through if this is 1<<%d)",
+					got.Hour, tc.hour, tc.hour)
+			}
+			if got.RepeatDate != dsmRepeatDaily {
+				t.Errorf("repeat_date = %d, want %d (daily)", got.RepeatDate, dsmRepeatDaily)
+			}
+			if got.WeekDay != "0,1,2,3,4,5,6" {
+				t.Errorf("week_day = %q, want all seven days", got.WeekDay)
+			}
+			if got.RepeatMin != 0 || got.RepeatHour != 0 {
+				t.Errorf("repeat_min/repeat_hour = %d/%d, want 0/0 for a fixed daily time",
+					got.RepeatMin, got.RepeatHour)
+			}
+		})
+	}
+}
+
+// The day-of-week field used to be parsed and then discarded, so "0 3 * * 1"
+// produced a task that ran every morning instead of on Mondays.
+func TestParseScheduleWeekdaysSelectDSMWeeklyMode(t *testing.T) {
+	for _, tc := range []struct {
+		spec    string
+		weekDay string
+	}{
+		{"17 3 * * 1", "1"},
+		{"17 3 * * 1-5", "1,2,3,4,5"},
+		{"17 3 * * 1,3", "1,3"},
+		{"17 3 * * 0", "0"},
+		{"17 3 * * 6", "6"},
+		{"17 3 * * mon", "1"},
+	} {
+		t.Run(tc.spec, func(t *testing.T) {
+			got, err := parseSchedule(tc.spec)
+			if err != nil {
+				t.Fatalf("parseSchedule(%q) returned error: %v", tc.spec, err)
+			}
+			if got.RepeatDate != dsmRepeatWeekly {
+				t.Errorf("repeat_date = %d, want %d (weekly)", got.RepeatDate, dsmRepeatWeekly)
+			}
+			if got.WeekDay != tc.weekDay {
+				t.Errorf("week_day = %q, want %q", got.WeekDay, tc.weekDay)
+			}
+			if got.Hour != 3 || got.Minute != 17 {
+				t.Errorf("hour/minute = %d/%d, want 3/17", got.Hour, got.Minute)
+			}
+		})
+	}
+}
+
+// "*" and "*/N" describe an interval, which DSM stores as repeat_min or
+// repeat_hour with hour/minute carrying the starting point.
+func TestParseScheduleIntervalsMapToRepeatCounters(t *testing.T) {
+	for _, tc := range []struct {
+		spec                  string
+		minute, hour          int64
+		repeatMin, repeatHour int64
+	}{
+		{"*/15 * * * *", 0, 0, 15, 0}, // every 15 minutes
+		{"5/15 * * * *", 5, 0, 15, 0}, // every 15 minutes from :05
+		{"* * * * *", 0, 0, 1, 0},     // every minute
+		{"30 */6 * * *", 30, 0, 0, 6}, // every 6 hours at :30
+		{"30 * * * *", 30, 0, 0, 1},   // every hour at :30
+		{"30 2/6 * * *", 30, 2, 0, 6}, // every 6 hours from 02:30
+		// A list whose values are evenly spaced and run to the end of the field
+		// IS an interval: ":00 and :30" is every 30 minutes, and DSM stores it
+		// as such. Rejecting these would refuse schedules the device supports.
+		{"0,30 * * * *", 0, 0, 30, 0},
+		{"0 3,15 * * *", 0, 3, 0, 12}, // every 12 hours from 03:00
+		// Equivalent to */15: minute 45 plus a 15-minute step runs past 59.
+		{"0-45/15 * * * *", 0, 0, 15, 0},
+	} {
+		t.Run(tc.spec, func(t *testing.T) {
+			got, err := parseSchedule(tc.spec)
+			if err != nil {
+				t.Fatalf("parseSchedule(%q) returned error: %v", tc.spec, err)
+			}
+			if got.Minute != tc.minute || got.Hour != tc.hour {
+				t.Errorf("hour/minute = %d/%d, want %d/%d",
+					got.Hour, got.Minute, tc.hour, tc.minute)
+			}
+			if got.RepeatMin != tc.repeatMin || got.RepeatHour != tc.repeatHour {
+				t.Errorf("repeat_min/repeat_hour = %d/%d, want %d/%d",
+					got.RepeatMin, got.RepeatHour, tc.repeatMin, tc.repeatHour)
+			}
+		})
+	}
+}
+
+// Weekly and interval combine: DSM accepted repeat_date 1002 with repeat_hour
+// set, and scheduled the next run on the next selected weekday.
+func TestParseScheduleWeeklyIntervalCombination(t *testing.T) {
+	got, err := parseSchedule("30 */6 * * 1,3")
+	if err != nil {
+		t.Fatalf("parseSchedule returned error: %v", err)
+	}
+	if got.RepeatDate != dsmRepeatWeekly || got.WeekDay != "1,3" {
+		t.Errorf("repeat_date/week_day = %d/%q, want %d/\"1,3\"",
+			got.RepeatDate, got.WeekDay, dsmRepeatWeekly)
+	}
+	if got.RepeatHour != 6 || got.Minute != 30 {
+		t.Errorf("repeat_hour/minute = %d/%d, want 6/30", got.RepeatHour, got.Minute)
+	}
+}
+
+// Schedules DSM cannot represent must fail at plan/apply. Accepting them
+// writes a task that looks healthy and never runs at the requested times.
+func TestParseScheduleRejectsWhatDSMCannotExpress(t *testing.T) {
+	for _, tc := range []struct {
+		name string
+		spec string
+	}{
+		{"bounded hour range", "0 9-17 * * *"},
+		{"bounded minute range", "10-20 3 * * *"},
+		{"stepped range stopping early", "0-30/15 * * * *"},
+		{"uneven minute list", "0,7,30 3 * * *"},
+		{"minute interval inside one hour", "*/15 3 * * *"},
+		{"day of month", "0 3 1 * *"},
+		{"day-of-month range", "0 3 1-7 * *"},
+		{"month restriction", "0 3 * 6 *"},
+		{"minute interval with stepped hours", "*/15 */6 * * *"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := parseSchedule(tc.spec)
+			if err == nil {
+				t.Fatalf("parseSchedule(%q) = %+v, want an error", tc.spec, got)
+			}
+		})
+	}
+}
+
+// An empty schedule is how the resource signals "run once, now".
+func TestParseScheduleEmptySpecIsNotAnError(t *testing.T) {
+	got, err := parseSchedule("")
+	if err != nil {
+		t.Fatalf("parseSchedule(\"\") returned error: %v", err)
+	}
+	if got.RepeatDate != 0 {
+		t.Errorf("repeat_date = %d, want the zero value", got.RepeatDate)
+	}
+}
+
+// An unparseable expression must surface util's error rather than a zero
+// schedule.
+func TestParseScheduleInvalidSpecReturnsError(t *testing.T) {
+	if _, err := parseSchedule("not a cron expression"); err == nil {
+		t.Fatal("parseSchedule(\"not a cron expression\") returned no error")
+	}
+}
+
+// The "@every ..." descriptors set only the repeat_* counters and leave every
+// cron field empty; they must pass through untouched.
+func TestParseScheduleEveryDescriptors(t *testing.T) {
+	for _, tc := range []struct {
+		spec                              string
+		repeatMin, repeatHour, repeatDate int64
+	}{
+		{"@every 15m", 15, 0, dsmRepeatDaily},
+		{"@every 6h", 0, 6, dsmRepeatDaily},
+		{"@every 48h", 0, 0, 2},
+	} {
+		t.Run(tc.spec, func(t *testing.T) {
+			got, err := parseSchedule(tc.spec)
+			if err != nil {
+				t.Fatalf("parseSchedule(%q) returned error: %v", tc.spec, err)
+			}
+			if got.RepeatMin != tc.repeatMin || got.RepeatHour != tc.repeatHour {
+				t.Errorf("repeat_min/repeat_hour = %d/%d, want %d/%d",
+					got.RepeatMin, got.RepeatHour, tc.repeatMin, tc.repeatHour)
+			}
+			if got.RepeatDate != tc.repeatDate {
+				t.Errorf("repeat_date = %d, want %d", got.RepeatDate, tc.repeatDate)
+			}
+			if got.Hour != 0 || got.Minute != 0 {
+				t.Errorf("hour/minute = %d/%d, want 0/0 for an interval schedule",
+					got.Hour, got.Minute)
+			}
+		})
+	}
+}
+
+// The named descriptors set hour and minute to bit 0, which must convert to
+// midnight rather than to the literal 1.
+func TestParseScheduleNamedDescriptors(t *testing.T) {
+	for _, tc := range []struct {
+		spec         string
+		hour, minute int64
+		repeatDate   int64
+		weekDay      string
+	}{
+		{"@daily", 0, 0, dsmRepeatDaily, "0,1,2,3,4,5,6"},
+		{"@midnight", 0, 0, dsmRepeatDaily, "0,1,2,3,4,5,6"},
+		{"@weekly", 0, 0, dsmRepeatWeekly, "0"},
+	} {
+		t.Run(tc.spec, func(t *testing.T) {
+			got, err := parseSchedule(tc.spec)
+			if err != nil {
+				t.Fatalf("parseSchedule(%q) returned error: %v", tc.spec, err)
+			}
+			if got.Hour != tc.hour || got.Minute != tc.minute {
+				t.Errorf("hour/minute = %d/%d, want %d/%d",
+					got.Hour, got.Minute, tc.hour, tc.minute)
+			}
+			if got.RepeatDate != tc.repeatDate {
+				t.Errorf("repeat_date = %d, want %d", got.RepeatDate, tc.repeatDate)
+			}
+			if got.WeekDay != tc.weekDay {
+				t.Errorf("week_day = %q, want %q", got.WeekDay, tc.weekDay)
+			}
+		})
+	}
+}
+
+// @hourly and @yearly restrict fields DSM cannot express; they must fail
+// loudly rather than be silently mis-stored.
+func TestParseScheduleUnsupportedDescriptors(t *testing.T) {
+	for _, spec := range []string{"@monthly", "@yearly", "@annually"} {
+		t.Run(spec, func(t *testing.T) {
+			if _, err := parseSchedule(spec); err == nil {
+				t.Fatalf("parseSchedule(%q) returned no error", spec)
+			}
+		})
+	}
+}
+
+func TestCronFieldValues(t *testing.T) {
+	// Bit 0 and bit 3 set, plus the star bit, which must be masked off before
+	// the values are read.
+	// Converted through a variable: int64(cronStarBit) is a constant
+	// conversion and overflows, which is why the parser does the same dance.
+	star := cronStarBit
+	mask := int64(1)<<0 | int64(1)<<3 | int64(star)
+	got := cronFieldValues(mask, 23)
+	if len(got) != 2 || got[0] != 0 || got[1] != 3 {
+		t.Fatalf("cronFieldValues = %v, want [0 3]", got)
+	}
+	if v := cronFieldValues(0, 59); len(v) != 0 {
+		t.Errorf("cronFieldValues(0) = %v, want empty", v)
+	}
+	// Values above max must not be reported.
+	if v := cronFieldValues(int64(1)<<40, 23); len(v) != 0 {
+		t.Errorf("cronFieldValues past max = %v, want empty", v)
+	}
+}
+
+func TestClassifyCronField(t *testing.T) {
+	t.Run("unset", func(t *testing.T) {
+		f, err := classifyCronField(0, 59, "minute")
+		if err != nil || f.start != 0 || f.step != 0 {
+			t.Fatalf("got %+v, %v; want zero field and no error", f, err)
+		}
+	})
+	t.Run("single value", func(t *testing.T) {
+		f, err := classifyCronField(int64(1)<<17, 59, "minute")
+		if err != nil || f.start != 17 || f.step != 0 {
+			t.Fatalf("got %+v, %v; want start 17 step 0", f, err)
+		}
+	})
+	t.Run("even interval to the end", func(t *testing.T) {
+		var mask int64
+		for _, v := range []uint{0, 15, 30, 45} {
+			mask |= int64(1) << v
+		}
+		f, err := classifyCronField(mask, 59, "minute")
+		if err != nil || f.start != 0 || f.step != 15 {
+			t.Fatalf("got %+v, %v; want start 0 step 15", f, err)
+		}
+	})
+	t.Run("uneven set is rejected", func(t *testing.T) {
+		mask := int64(1)<<0 | int64(1)<<15 | int64(1)<<31
+		if _, err := classifyCronField(mask, 59, "minute"); err == nil {
+			t.Fatal("uneven values were accepted")
+		}
+	})
+	t.Run("interval stopping early is rejected", func(t *testing.T) {
+		mask := int64(1)<<0 | int64(1)<<10 | int64(1)<<20
+		if _, err := classifyCronField(mask, 59, "minute"); err == nil {
+			t.Fatal("bounded window was accepted")
+		}
+	})
+}
+
+func TestCronFieldString(t *testing.T) {
+	if got := cronFieldString([]int64{1, 3, 5}); got != "1,3,5" {
+		t.Errorf("cronFieldString = %q, want \"1,3,5\"", got)
+	}
+	if got := cronFieldString(nil); got != "" {
+		t.Errorf("cronFieldString(nil) = %q, want empty", got)
+	}
+}
+
+func TestWeekDayString(t *testing.T) {
+	if got := weekDayString([]int64{1, 2, 3, 4, 5}); got != "1,2,3,4,5" {
+		t.Errorf("weekDayString = %q, want \"1,2,3,4,5\"", got)
+	}
+}


### PR DESCRIPTION
Fixes #210.

## Two silent bugs

`parseSchedule` assigns `util.Schedule`'s **bitfields** straight into `core.TaskSchedule`'s **literal** fields, and discards the day-of-week field entirely. In both cases the task is created, DSM reports it enabled, and it runs at the wrong time or never:

| `schedule` | what DSM ends up doing |
|---|---|
| `17 3 * * *` | `/etc/crontab`: `131072 8 * * *` — never fires |
| `0 7 * * *` | `/etc/crontab`: `1 128 * * *` — never fires |
| `0 3 * * 1` | runs **every day** at 03:00 instead of Mondays |

Wildcards are worse still: the parser's star bit is the sign bit, so `30 * * * *` wrote a negative hour. In our case the affected task was an unattended Let's Encrypt renewal, so the failure would have surfaced ~90 days later as an expired certificate.

## What DSM actually supports

Rather than infer this, I probed a live **DSM 7.4** with disabled throwaway tasks and read back both the stored schedule and `next_trigger_time`:

| DSM fields | Meaning |
|---|---|
| `repeat_date: 1001` + `hour`/`minute` | daily at that time |
| `repeat_date: 1002` + `week_day` | weekly on those days |
| `repeat_hour: N` (start = `hour`:`minute`) | every N hours |
| `repeat_min: N` (start = `:minute`) | every N minutes |

Two findings shaped the fix:

- **`week_day` is only honoured when `repeat_date` is 1002.** With 1001 DSM silently normalises it back to all seven days — so day-of-week support was always available, just unused.
- **DSM validates nothing.** `hour: 128` is accepted, stored, and displayed as `next_trigger_time: "2026-08-03 128:01"`. All validation has to live in the provider.

## The fix

`parseSchedule` now maps:

- fixed time → daily (`1001`)
- day-of-week restriction → weekly (`1002` + `week_day`)
- even interval → `repeat_min` / `repeat_hour`, with `hour`/`minute` carrying the start

and **rejects, with an explanatory error, what DSM cannot represent**: day-of-month or month restrictions, bounded windows (`0 9-17 * * *`), unevenly spaced lists (`0,7,30`), and an interval confined to one hour (`*/15 3 * * *`). Those are all silently mis-stored today, so erroring surfaces existing bugs rather than introducing new ones.

Note that evenly spaced lists **are** intervals and are supported: `0,30 * * * *` is every 30 minutes, and `0-45/15` is equivalent to `*/15`. My first draft rejected those; writing the tests proved it wrong.

`@every ...` descriptors keep passing through untouched — they set only the repeat counters and leave the cron fields empty, which the conversion has to treat as "unset" rather than "no value".

## Verification

- **Unit tests at 100% statement coverage of the new code** (`parseSchedule`, `cronFieldValues`, `classifyCronField`, and helpers) covering each mapping, each rejection, and both descriptor families.
- **Every mapping replayed against the live device.** The clearest proof of the day-of-week fix: from a Monday, `17 3 * * 1` scheduled its next run **seven days out (08-10)** while `17 3 * * 1-5` scheduled **tomorrow (08-04)**.
- `go build`, `go vet`, `gofmt` clean.
- Two pre-existing failures on my machine are unrelated and unchanged: `synology/util`'s `TestGetValue` panics on clean `main` too, and the acceptance tests need a `terraform` binary my environment can't auto-install.

Docs and the attribute description now state the supported subset, since users get errors where they previously got silence.

Happy to split the day-of-week fix into its own PR if you'd prefer them reviewed separately — they're one function, but they are two distinct bugs.