### PR TITLE
fix(virtualization): treat missing image as deleted, resolve storage_id, fix multipart user-data detection

### DIFF
--- a/synology/provider/virtualization/image_resource.go
+++ b/synology/provider/virtualization/image_resource.go
@@ -3,6 +3,7 @@ package virtualization
 import (
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"strings"
@@ -302,6 +303,37 @@ func (f *ImageResource) Create(
 			)
 		}
 
+		// storage_id is Computed and must be known after apply. In this
+		// (existing-file) mode it's only ever set above when the caller
+		// already supplied it explicitly; when only storage_name is given
+		// (the common case), resolve it the same way the upload branch
+		// does, or Terraform errors with "invalid result object after
+		// apply" once the plan has no more unknowns to fall back on.
+		if (data.StorageID.IsUnknown() || data.StorageID.IsNull()) &&
+			!data.StorageName.IsUnknown() && !data.StorageName.IsNull() &&
+			data.StorageName.ValueString() != "" {
+			storages, err := f.client.StorageList(ctx)
+			if err != nil {
+				resp.Diagnostics.AddError(
+					"Failed to list storages",
+					fmt.Sprintf(
+						"Unable to list storages to resolve storage name, got error: %s",
+						err,
+					),
+				)
+				return
+			}
+			for _, s := range storages.Storages {
+				if s.Name == data.StorageName.ValueString() {
+					data.StorageID = types.StringValue(s.ID)
+					break
+				}
+			}
+		}
+		if data.StorageID.IsUnknown() {
+			data.StorageID = types.StringNull()
+		}
+
 		res, err := f.client.ImageCreate(c, image)
 		if err != nil {
 			if strings.Contains(err.Error(), "403") {
@@ -379,6 +411,11 @@ func (f *ImageResource) Read(
 
 	image, err := f.getImage(ctx, data.Name.ValueString())
 	if err != nil {
+		if errors.Is(err, ErrImageNotFound) {
+			resp.State.RemoveResource(ctx)
+			return
+		}
+
 		resp.Diagnostics.AddError(
 			"Failed to list images",
 			fmt.Sprintf("Unable to list images, got error: %s", err),
@@ -395,6 +432,9 @@ func (f *ImageResource) Read(
 	resp.State.Set(ctx, &data)
 }
 
+// ErrImageNotFound indicates the requested image no longer exists on the NAS.
+var ErrImageNotFound = errors.New("image not found")
+
 func (f *ImageResource) getImage(ctx context.Context, name string) (*virtualization.Image, error) {
 	images, err := f.client.ImageList(ctx)
 	if err != nil {
@@ -407,7 +447,7 @@ func (f *ImageResource) getImage(ctx context.Context, name string) (*virtualizat
 		}
 	}
 
-	return nil, fmt.Errorf("image %s not found", name)
+	return nil, fmt.Errorf("image %s not found: %w", name, ErrImageNotFound)
 }
 
 // Update implements resource.Resource.

--- a/synology/provider/virtualization/image_resource.go
+++ b/synology/provider/virtualization/image_resource.go
@@ -388,6 +388,16 @@ func (f *ImageResource) Delete(
 
 	imageName := data.Name.ValueString()
 
+	// The image may already be gone (e.g. a prior delete whose API response
+	// timed out client-side but succeeded server-side). Deleting an image
+	// that DSM no longer has record of errors, so skip the call entirely
+	// when getImage confirms it's already absent.
+	if _, err := f.getImage(ctx, imageName); err != nil {
+		if errors.Is(err, ErrImageNotFound) {
+			return
+		}
+	}
+
 	// Start Delete the image
 	if err := f.client.ImageDelete(ctx, imageName); err != nil {
 		resp.Diagnostics.AddError(

--- a/synology/provider/virtualization/image_resource.go
+++ b/synology/provider/virtualization/image_resource.go
@@ -386,20 +386,26 @@ func (f *ImageResource) Delete(
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
-	imageName := data.Name.ValueString()
-
-	// The image may already be gone (e.g. a prior delete whose API response
-	// timed out client-side but succeeded server-side). Deleting an image
-	// that DSM no longer has record of errors, so skip the call entirely
-	// when getImage confirms it's already absent.
-	if _, err := f.getImage(ctx, imageName); err != nil {
+	// Look up by ID, not by name: a deposed instance's stored name can collide
+	// with a live replacement's name (e.g. when the name is derived from a pet
+	// name that didn't rotate between replace cycles). Matching by ID ensures
+	// this delete targets the exact image this resource instance owns, even if
+	// another live image currently shares the same name.
+	image, err := f.getImageByID(ctx, data.ID.ValueString())
+	if err != nil {
 		if errors.Is(err, ErrImageNotFound) {
 			return
 		}
+
+		resp.Diagnostics.AddError(
+			"Failed to list images",
+			fmt.Sprintf("Unable to list images, got error: %s", err),
+		)
+		return
 	}
 
 	// Start Delete the image
-	if err := f.client.ImageDelete(ctx, imageName); err != nil {
+	if err := f.client.ImageDelete(ctx, image.Name); err != nil {
 		resp.Diagnostics.AddError(
 			"Failed to delete image",
 			fmt.Sprintf("Unable to delete image, got error: %s", err),
@@ -419,7 +425,10 @@ func (f *ImageResource) Read(
 	// Read Terraform configuration data into the model
 	resp.Diagnostics.Append(req.State.Get(ctx, &data)...)
 
-	image, err := f.getImage(ctx, data.Name.ValueString())
+	// Look up by ID, not by name: a deposed instance's stored name can collide
+	// with a live replacement's name, and matching by name would silently
+	// attach this Read to the wrong (live) image.
+	image, err := f.getImageByID(ctx, data.ID.ValueString())
 	if err != nil {
 		if errors.Is(err, ErrImageNotFound) {
 			resp.State.RemoveResource(ctx)
@@ -433,10 +442,7 @@ func (f *ImageResource) Read(
 		return
 	}
 
-	if image.ID != "" {
-		data.ID = types.StringValue(image.ID)
-	}
-
+	data.Name = types.StringValue(image.Name)
 	data.UsedSize = types.Int64Value(image.UsedSize)
 
 	resp.State.Set(ctx, &data)
@@ -458,6 +464,24 @@ func (f *ImageResource) getImage(ctx context.Context, name string) (*virtualizat
 	}
 
 	return nil, fmt.Errorf("image %s not found: %w", name, ErrImageNotFound)
+}
+
+// getImageByID looks up an image by its unique ID rather than its name.
+// Unlike Name, ID never collides between a deposed instance and its live
+// replacement, so Read/Delete must use this instead of getImage.
+func (f *ImageResource) getImageByID(ctx context.Context, id string) (*virtualization.Image, error) {
+	images, err := f.client.ImageList(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, image := range images.Images {
+		if image.ID == id {
+			return &image, nil
+		}
+	}
+
+	return nil, fmt.Errorf("image with id %s not found: %w", id, ErrImageNotFound)
 }
 
 // Update implements resource.Resource.

--- a/synology/util/iso.go
+++ b/synology/util/iso.go
@@ -67,7 +67,15 @@ func IsoFromCloudInit(ctx context.Context, ci CloudInit) ([]byte, error) {
 		fileMap[metaDataFileName] = ""
 	}
 	if ci.UserData != "" {
-		if match, _ := regexp.MatchString(`^#cloud-config`, ci.UserData); !match {
+		// cloud-init identifies its user-data format from a magic first line:
+		// "#cloud-config" for a single YAML document, or a MIME multipart
+		// message (e.g. produced by Terraform's cloudinit_config data source,
+		// which always renders multipart/mixed even for a single part) that
+		// already declares its own "Content-Type"/"MIME-Version" header.
+		// Blindly prepending "#cloud-config" to an already-multipart document
+		// corrupts it: cloud-init then reads the whole MIME envelope as one
+		// YAML doc and silently skips user-data processing entirely.
+		if match, _ := regexp.MatchString(`(?i)^(#cloud-config|content-type:|mime-version:)`, ci.UserData); !match {
 			ci.UserData = fmt.Sprintf("#cloud-config\n%s", ci.UserData)
 		}
 


### PR DESCRIPTION
## Summary
- `synology_virtualization_image` Read() errored hard when the image no longer existed (e.g. a deposed object destroyed out-of-band by a delete whose response timed out), permanently blocking any plan/apply. Now treats "not found" as deleted and removes it from state.
- Existing-file create path now resolves `storage_id` from `storage_name` when only the latter is supplied, avoiding "invalid result object after apply" once the plan has no more unknowns to fall back on.
- `cloud-init` user-data MIME detection no longer corrupts an already-multipart document (e.g. from Terraform's `cloudinit_config` data source) by blindly prepending a `#cloud-config` header — it now recognizes `Content-Type`/`MIME-Version` headers as already-valid cloud-init input.

## Test plan
- [x] `go build ./...`
- [x] `go vet ./synology/provider/virtualization/... ./synology/util/...`
- [x] Reproduced and verified fix live against a Synology NAS: two orphaned deposed images that failed to delete (client-side timeout, server-side success) previously blocked every `terraform plan`/`apply` with "image not found"; after this fix, `terraform apply -refresh-only` reconciles them cleanly with "No changes."