### PR TITLE
feat(core_task): add notification settings

### DIFF
--- a/docs/resources/core_task.md
+++ b/docs/resources/core_task.md
@@ -21,6 +21,9 @@ A Generic API Resource for making calls to the Synology DSM API.
 
 ### Optional
 
+- `notify_enable` (Boolean) Whether DSM emails the task's run details.
+- `notify_if_error` (Boolean) Whether DSM sends run details only when the task fails.
+- `notify_mail` (String) Email address that receives task run details. Required when `notify_enable` is true.
 - `run` (Boolean) Whether to run the task after creation.
 - `schedule` (String) Schedule expressed in cron, mapped onto DSM's scheduler: a fixed time (`17 3 * * *`) becomes a daily task, a day-of-week restriction (`17 3 * * 1-5`) becomes a weekly one, and an even interval (`*/15 * * * *`, `30 */6 * * *`) becomes DSM's repeat_min/repeat_hour. Schedules DSM cannot represent are rejected rather than silently mis-stored: day-of-month or month restrictions, bounded windows (`0 9-17 * * *`), and unevenly spaced lists (`0,7,30`).
 - `script` (String) Script content to run in the task.

--- a/synology/provider/core/task_notification_test.go
+++ b/synology/provider/core/task_notification_test.go
@@ -1,0 +1,136 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	coreapi "github.com/synology-community/go-synology/pkg/api/core"
+)
+
+type stubTaskNotificationUpdateAPI struct {
+	coreapi.Api
+}
+
+func (*stubTaskNotificationUpdateAPI) TaskUpdate(
+	context.Context,
+	coreapi.TaskRequest,
+) (*coreapi.TaskResult, error) {
+	return &coreapi.TaskResult{}, nil
+}
+
+func TestGetTaskRequestMapsNotifications(t *testing.T) {
+	data := taskNotificationModel()
+	data.NotifyEnable = types.BoolValue(true)
+	data.NotifyIfError = types.BoolValue(true)
+	data.NotifyMail = types.StringValue("admin@example.com")
+
+	req, err := getTaskRequest(data)
+	if err != nil {
+		t.Fatalf("getTaskRequest() error = %v", err)
+	}
+	if !req.Extra.NotifyEnable || !req.Extra.NotifyIfError ||
+		req.Extra.NotifyMail != "admin@example.com" {
+		t.Errorf("notification request = %#v, want enabled error notifications", req.Extra)
+	}
+}
+
+func TestUpdateWritesNotificationsToState(t *testing.T) {
+	ctx := context.Background()
+	provider := &TaskResource{client: &stubTaskNotificationUpdateAPI{}}
+	schemaResp := &resource.SchemaResponse{}
+	provider.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema returned diagnostics: %v", schemaResp.Diagnostics)
+	}
+
+	prior := taskNotificationModel()
+	planned := prior
+	planned.NotifyEnable = types.BoolValue(true)
+	planned.NotifyIfError = types.BoolValue(true)
+	planned.NotifyMail = types.StringValue("admin@example.com")
+
+	state := tfsdk.State{Schema: schemaResp.Schema}
+	if diagnostics := state.Set(ctx, &prior); diagnostics.HasError() {
+		t.Fatalf("state.Set() diagnostics: %v", diagnostics)
+	}
+	plan := tfsdk.Plan{Schema: schemaResp.Schema}
+	if diagnostics := plan.Set(ctx, &planned); diagnostics.HasError() {
+		t.Fatalf("plan.Set() diagnostics: %v", diagnostics)
+	}
+	response := &resource.UpdateResponse{State: state}
+	provider.Update(ctx, resource.UpdateRequest{Plan: plan, State: state}, response)
+	if response.Diagnostics.HasError() {
+		t.Fatalf("Update() diagnostics: %v", response.Diagnostics)
+	}
+
+	var result TaskResourceModel
+	if diagnostics := response.State.Get(ctx, &result); diagnostics.HasError() {
+		t.Fatalf("response.State.Get() diagnostics: %v", diagnostics)
+	}
+	if !result.NotifyEnable.ValueBool() || !result.NotifyIfError.ValueBool() ||
+		result.NotifyMail.ValueString() != "admin@example.com" {
+		t.Errorf("notification state = %#v, want planned values", result)
+	}
+}
+
+func TestValidateConfigRequiresNotificationMail(t *testing.T) {
+	tests := []struct {
+		name        string
+		notify      types.Bool
+		mail        types.String
+		expectError bool
+	}{
+		{"enabled with mail", types.BoolValue(true), types.StringValue("admin@example.com"), false},
+		{"enabled with empty mail", types.BoolValue(true), types.StringValue(""), true},
+		{"enabled with null mail", types.BoolValue(true), types.StringNull(), true},
+		{"disabled without mail", types.BoolValue(false), types.StringNull(), false},
+		{"enabled with unknown mail", types.BoolValue(true), types.StringUnknown(), false},
+	}
+
+	ctx := context.Background()
+	provider := &TaskResource{}
+	schemaResp := &resource.SchemaResponse{}
+	provider.Schema(ctx, resource.SchemaRequest{}, schemaResp)
+	if schemaResp.Diagnostics.HasError() {
+		t.Fatalf("schema returned diagnostics: %v", schemaResp.Diagnostics)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			model := taskNotificationModel()
+			model.NotifyEnable = tt.notify
+			model.NotifyMail = tt.mail
+			state := tfsdk.State{Schema: schemaResp.Schema}
+			if diagnostics := state.Set(ctx, &model); diagnostics.HasError() {
+				t.Fatalf("state.Set() diagnostics: %v", diagnostics)
+			}
+
+			response := &resource.ValidateConfigResponse{}
+			provider.ValidateConfig(ctx, resource.ValidateConfigRequest{
+				Config: tfsdk.Config{Raw: state.Raw, Schema: schemaResp.Schema},
+			}, response)
+			if got := response.Diagnostics.HasError(); got != tt.expectError {
+				t.Errorf("ValidateConfig() has error = %v, want %v", got, tt.expectError)
+			}
+		})
+	}
+}
+
+func taskNotificationModel() TaskResourceModel {
+	return TaskResourceModel{
+		ID:            types.Int64Value(1),
+		Name:          types.StringValue("test"),
+		Service:       types.StringNull(),
+		Script:        types.StringValue("echo test"),
+		Schedule:      types.StringNull(),
+		User:          types.StringValue("terraform"),
+		NotifyEnable:  types.BoolValue(false),
+		NotifyIfError: types.BoolValue(false),
+		NotifyMail:    types.StringValue(""),
+		Run:           types.BoolValue(false),
+		When:          types.StringValue("apply"),
+	}
+}

--- a/synology/provider/core/task_resource.go
+++ b/synology/provider/core/task_resource.go
@@ -31,6 +31,10 @@ type TaskResourceModel struct {
 	Schedule types.String `tfsdk:"schedule"`
 	User     types.String `tfsdk:"user"`
 
+	NotifyEnable  types.Bool   `tfsdk:"notify_enable"`
+	NotifyIfError types.Bool   `tfsdk:"notify_if_error"`
+	NotifyMail    types.String `tfsdk:"notify_mail"`
+
 	Run  types.Bool   `tfsdk:"run"`
 	When types.String `tfsdk:"when"`
 }
@@ -132,6 +136,16 @@ func (p *TaskResource) Update(
 		resp.Diagnostics.AddError("Task install failed", err.Error())
 		return
 	}
+
+	resp.Diagnostics.Append(
+		resp.State.SetAttribute(ctx, path.Root("notify_enable"), plan.NotifyEnable)...,
+	)
+	resp.Diagnostics.Append(
+		resp.State.SetAttribute(ctx, path.Root("notify_if_error"), plan.NotifyIfError)...,
+	)
+	resp.Diagnostics.Append(
+		resp.State.SetAttribute(ctx, path.Root("notify_mail"), plan.NotifyMail)...,
+	)
 
 	if plan.Run.ValueBool() != state.Run.ValueBool() {
 		resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("run"), plan.Run)...)
@@ -274,6 +288,24 @@ func (p *TaskResource) Schema(
 				MarkdownDescription: "The user that will execute the task.",
 				Required:            true,
 			},
+			"notify_enable": schema.BoolAttribute{
+				MarkdownDescription: "Whether DSM emails the task's run details.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"notify_if_error": schema.BoolAttribute{
+				MarkdownDescription: "Whether DSM sends run details only when the task fails.",
+				Optional:            true,
+				Computed:            true,
+				Default:             booldefault.StaticBool(false),
+			},
+			"notify_mail": schema.StringAttribute{
+				MarkdownDescription: "Email address that receives task run details. Required when `notify_enable` is true.",
+				Optional:            true,
+				Computed:            true,
+				Default:             stringdefault.StaticString(""),
+			},
 			"run": schema.BoolAttribute{
 				MarkdownDescription: "Whether to run the task after creation.",
 				Optional:            true,
@@ -290,6 +322,27 @@ func (p *TaskResource) Schema(
 				},
 			},
 		},
+	}
+}
+
+func (p *TaskResource) ValidateConfig(
+	ctx context.Context,
+	req resource.ValidateConfigRequest,
+	resp *resource.ValidateConfigResponse,
+) {
+	var data TaskResourceModel
+	resp.Diagnostics.Append(req.Config.Get(ctx, &data)...)
+	if resp.Diagnostics.HasError() || data.NotifyEnable.IsNull() || data.NotifyEnable.IsUnknown() ||
+		!data.NotifyEnable.ValueBool() || data.NotifyMail.IsUnknown() {
+		return
+	}
+
+	if data.NotifyMail.IsNull() || data.NotifyMail.ValueString() == "" {
+		resp.Diagnostics.AddAttributeError(
+			path.Root("notify_mail"),
+			"Missing notification email",
+			"notify_mail must be set when notify_enable is true.",
+		)
 	}
 }
 
@@ -574,7 +627,10 @@ func getTaskRequest(data TaskResourceModel) (taskReq core.TaskRequest, err error
 		Owner:     user,
 		Type:      taskType,
 		Extra: core.TaskExtra{
-			Script: data.Script.ValueString(),
+			Script:        data.Script.ValueString(),
+			NotifyEnable:  data.NotifyEnable.ValueBool(),
+			NotifyIfError: data.NotifyIfError.ValueBool(),
+			NotifyMail:    data.NotifyMail.ValueString(),
 		},
 	}
 


### PR DESCRIPTION
Make it possible to set email notification settings for failed scheduled/triggered tasks.