### PR TITLE
feat: add synology_core_share_permission resource

### DIFF
--- a/synology/provider/core/core.go
+++ b/synology/provider/core/core.go
@@ -15,6 +15,7 @@ func Resources() []func() resource.Resource {
 		NewPackageFeedResource,
 		NewTaskResource,
 		NewEventResource,
+		NewSharePermissionResource,
 	}
 }
 

--- a/synology/provider/core/share_permission_resource.go
+++ b/synology/provider/core/share_permission_resource.go
@@ -1,0 +1,444 @@
+package core
+
+import (
+	"context"
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/hashicorp/terraform-plugin-framework-validators/stringvalidator"
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/booldefault"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/planmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema/stringplanmodifier"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/synology-community/go-synology"
+	"github.com/synology-community/go-synology/pkg/api/core"
+)
+
+var (
+	_ resource.Resource                = &SharePermissionResource{}
+	_ resource.ResourceWithImportState = &SharePermissionResource{}
+)
+
+func NewSharePermissionResource() resource.Resource {
+	return &SharePermissionResource{}
+}
+
+type SharePermissionResource struct {
+	client core.Api
+}
+
+// SharePermissionResourceModel owns the *entire* SYNO.Core.Share.Permission
+// list for one (share, user_group_type) pair -- see the schema description
+// for why full ownership was chosen over a per-account resource.
+type SharePermissionResourceModel struct {
+	Share         types.String `tfsdk:"share"`
+	UserGroupType types.String `tfsdk:"user_group_type"`
+	Permission    types.Set    `tfsdk:"permission"`
+}
+
+type sharePermissionEntryModel struct {
+	Name       types.String `tfsdk:"name"`
+	IsReadonly types.Bool   `tfsdk:"is_readonly"`
+	IsWritable types.Bool   `tfsdk:"is_writable"`
+	IsDeny     types.Bool   `tfsdk:"is_deny"`
+	IsCustom   types.Bool   `tfsdk:"is_custom"`
+	IsAdmin    types.Bool   `tfsdk:"is_admin"`
+}
+
+func sharePermissionEntryAttrTypes() map[string]attr.Type {
+	return map[string]attr.Type{
+		"name":        types.StringType,
+		"is_readonly": types.BoolType,
+		"is_writable": types.BoolType,
+		"is_deny":     types.BoolType,
+		"is_custom":   types.BoolType,
+		"is_admin":    types.BoolType,
+	}
+}
+
+func (r *SharePermissionResource) Metadata(
+	_ context.Context,
+	req resource.MetadataRequest,
+	resp *resource.MetadataResponse,
+) {
+	resp.TypeName = buildName(req.ProviderTypeName, "share_permission")
+}
+
+func (r *SharePermissionResource) Schema(
+	_ context.Context,
+	_ resource.SchemaRequest,
+	resp *resource.SchemaResponse,
+) {
+	resp.Schema = schema.Schema{
+		MarkdownDescription: "Manages the complete `SYNO.Core.Share.Permission` list for one " +
+			"share and one `user_group_type` (all local-user grants, or all local-group grants, " +
+			"on that share -- never both from the same resource instance).\n\n" +
+			"**Full ownership.** Every apply overwrites the declared side's permission list to " +
+			"exactly the `permission` blocks in config. Any row added out-of-band -- DSM Control " +
+			"Panel, another tool, an operator -- is treated as drift and removed on the next " +
+			"apply. This mirrors how `synology_core_firewall_profile` already owns its full rule " +
+			"set in this provider: a resource that only reconciled the rows it happened to " +
+			"declare could never express \"revoke a grant someone else added,\" and two writers " +
+			"of the same share's permissions could drift forever with no single source of truth. " +
+			"Declare every row you want to exist; nothing else survives an apply.\n\n" +
+			"**The `administrators` local group is not manageable here.** DSM grants it " +
+			"read/write on every share unconditionally and offers no way to revoke it -- it is " +
+			"excluded from state on every read and rejected if declared in config, so this " +
+			"resource never plans a change it cannot converge.\n\n" +
+			"**`is_admin` is read-only.** It reflects DSM's own admin-group flag on the row, not " +
+			"a settable grant; it cannot be supplied in config.\n\n" +
+			"**Deny vs. no access.** `is_deny = true` is an explicit deny entry, distinct from a " +
+			"row with every flag false (no access granted, no explicit deny either).",
+		Attributes: map[string]schema.Attribute{
+			"share": schema.StringAttribute{
+				MarkdownDescription: "Share name. Changing this forces replacement.",
+				Required:            true,
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+			"user_group_type": schema.StringAttribute{
+				MarkdownDescription: "Which side of the permission list this resource owns: " +
+					"`local_user` or `local_group`. Changing this forces replacement.",
+				Required: true,
+				Validators: []validator.String{
+					stringvalidator.OneOf(
+						core.ShareUserGroupTypeLocalUser,
+						core.ShareUserGroupTypeLocalGroup,
+					),
+				},
+				PlanModifiers: []planmodifier.String{
+					stringplanmodifier.RequiresReplace(),
+				},
+			},
+		},
+		Blocks: map[string]schema.Block{
+			"permission": schema.SetNestedBlock{
+				MarkdownDescription: "One permission row per account (user or group name, " +
+					"matching `user_group_type`). Order does not matter.",
+				NestedObject: schema.NestedBlockObject{
+					Attributes: map[string]schema.Attribute{
+						"name": schema.StringAttribute{
+							MarkdownDescription: "Account (user or group) name.",
+							Required:            true,
+						},
+						"is_readonly": schema.BoolAttribute{
+							MarkdownDescription: "Read-only access.",
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+						},
+						"is_writable": schema.BoolAttribute{
+							MarkdownDescription: "Read/write access.",
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+						},
+						"is_deny": schema.BoolAttribute{
+							MarkdownDescription: "Explicit deny, distinct from no access " +
+								"(all flags false).",
+							Optional: true,
+							Computed: true,
+							Default:  booldefault.StaticBool(false),
+						},
+						"is_custom": schema.BoolAttribute{
+							MarkdownDescription: "Custom (non-preset) permission.",
+							Optional:            true,
+							Computed:            true,
+							Default:             booldefault.StaticBool(false),
+						},
+						"is_admin": schema.BoolAttribute{
+							MarkdownDescription: "DSM-reported administrator flag for this row. " +
+								"Read-only: reflects group membership, not a grant, and cannot be " +
+								"set from config.",
+							Computed: true,
+						},
+					},
+				},
+			},
+		},
+	}
+}
+
+func (r *SharePermissionResource) Configure(
+	_ context.Context,
+	req resource.ConfigureRequest,
+	resp *resource.ConfigureResponse,
+) {
+	if req.ProviderData == nil {
+		return
+	}
+	client, ok := req.ProviderData.(synology.Api)
+	if !ok {
+		resp.Diagnostics.AddError(
+			"Unexpected Resource Configure Type",
+			fmt.Sprintf("Expected synology.Api, got: %T", req.ProviderData),
+		)
+		return
+	}
+	r.client = client.CoreAPI()
+}
+
+// planEntries decodes the plan's permission set into client entries, in a
+// stable (name-sorted) order so successive applies produce a stable diff.
+func (r *SharePermissionResource) planEntries(
+	ctx context.Context,
+	data SharePermissionResourceModel,
+) ([]core.SharePermissionSetEntry, error) {
+	if data.Permission.IsNull() || data.Permission.IsUnknown() {
+		return nil, nil
+	}
+	var rows []sharePermissionEntryModel
+	if diags := data.Permission.ElementsAs(ctx, &rows, false); diags.HasError() {
+		return nil, fmt.Errorf("permission decode: %s", diags.Errors())
+	}
+	entries := make([]core.SharePermissionSetEntry, 0, len(rows))
+	for _, row := range rows {
+		entries = append(entries, core.SharePermissionSetEntry{
+			Name:       row.Name.ValueString(),
+			IsReadonly: row.IsReadonly.ValueBool(),
+			IsWritable: row.IsWritable.ValueBool(),
+			IsDeny:     row.IsDeny.ValueBool(),
+			IsCustom:   row.IsCustom.ValueBool(),
+		})
+	}
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name < entries[j].Name })
+	return entries, nil
+}
+
+// rejectAdminEntries fails the plan if config declares a row that DSM
+// reports as administrator-flagged (constant 1 above: never plan a change
+// this resource can't converge -- administrators always has RW and cannot
+// be revoked).
+func (r *SharePermissionResource) rejectAdminEntries(
+	entries []core.SharePermissionSetEntry,
+	current *core.SharePermissionListResponse,
+) error {
+	admin := map[string]bool{}
+	if current != nil {
+		for _, item := range current.Items {
+			if item.IsAdmin {
+				admin[item.Name] = true
+			}
+		}
+	}
+	var bad []string
+	for _, e := range entries {
+		if admin[e.Name] {
+			bad = append(bad, e.Name)
+		}
+	}
+	if len(bad) > 0 {
+		return fmt.Errorf(
+			"account(s) %s are DSM administrator-flagged: they always have read/write on "+
+				"every share and DSM offers no way to revoke it; remove the permission block(s) "+
+				"declaring them",
+			strings.Join(bad, ", "),
+		)
+	}
+	return nil
+}
+
+func (r *SharePermissionResource) apply(
+	ctx context.Context,
+	data SharePermissionResourceModel,
+) error {
+	entries, err := r.planEntries(ctx, data)
+	if err != nil {
+		return err
+	}
+
+	share := data.Share.ValueString()
+	userGroupType := data.UserGroupType.ValueString()
+
+	current, err := r.client.SharePermissionList(ctx, share, userGroupType)
+	if err != nil {
+		return fmt.Errorf("permission list: %w", err)
+	}
+	if err := r.rejectAdminEntries(entries, current); err != nil {
+		return err
+	}
+
+	// Full ownership: also revoke any row present remotely but absent from
+	// config (dropped by name from the current list; a row with no flags
+	// set is equivalent to no access).
+	declared := map[string]bool{}
+	for _, e := range entries {
+		declared[e.Name] = true
+	}
+	if current != nil {
+		for _, item := range current.Items {
+			if item.IsAdmin || declared[item.Name] {
+				continue
+			}
+			entries = append(entries, core.SharePermissionSetEntry{Name: item.Name})
+		}
+	}
+
+	if err := r.client.SharePermissionSet(ctx, share, userGroupType, entries); err != nil {
+		return fmt.Errorf("permission set: %w", err)
+	}
+	return nil
+}
+
+func (r *SharePermissionResource) refresh(
+	ctx context.Context,
+	data *SharePermissionResourceModel,
+) error {
+	got, err := r.client.SharePermissionList(
+		ctx,
+		data.Share.ValueString(),
+		data.UserGroupType.ValueString(),
+	)
+	if err != nil {
+		return err
+	}
+
+	items := make([]core.SharePermission, 0, len(got.Items))
+	for _, item := range got.Items {
+		// administrators (or any other DSM-flagged admin row) is never
+		// managed by this resource and must never enter state -- otherwise
+		// every plan would want to delete a row config never declared.
+		if item.IsAdmin {
+			continue
+		}
+		items = append(items, item)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+
+	rowObjs := make([]attr.Value, 0, len(items))
+	for _, item := range items {
+		obj, diags := types.ObjectValue(sharePermissionEntryAttrTypes(), map[string]attr.Value{
+			"name":        types.StringValue(item.Name),
+			"is_readonly": types.BoolValue(item.IsReadonly),
+			"is_writable": types.BoolValue(item.IsWritable),
+			"is_deny":     types.BoolValue(item.IsDeny),
+			"is_custom":   types.BoolValue(item.IsCustom),
+			"is_admin":    types.BoolValue(item.IsAdmin),
+		})
+		if diags.HasError() {
+			return fmt.Errorf("permission object: %s", diags.Errors())
+		}
+		rowObjs = append(rowObjs, obj)
+	}
+	set, diags := types.SetValue(
+		types.ObjectType{AttrTypes: sharePermissionEntryAttrTypes()},
+		rowObjs,
+	)
+	if diags.HasError() {
+		return fmt.Errorf("permission set: %s", diags.Errors())
+	}
+	data.Permission = set
+	return nil
+}
+
+func (r *SharePermissionResource) Create(
+	ctx context.Context,
+	req resource.CreateRequest,
+	resp *resource.CreateResponse,
+) {
+	var plan SharePermissionResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.apply(ctx, plan); err != nil {
+		resp.Diagnostics.AddError("Failed to set share permissions", err.Error())
+		return
+	}
+	if err := r.refresh(ctx, &plan); err != nil {
+		resp.Diagnostics.AddError("Failed to read share permissions after create", err.Error())
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *SharePermissionResource) Read(
+	ctx context.Context,
+	req resource.ReadRequest,
+	resp *resource.ReadResponse,
+) {
+	var state SharePermissionResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.refresh(ctx, &state); err != nil {
+		resp.Diagnostics.AddError("Failed to read share permissions", err.Error())
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &state)...)
+}
+
+func (r *SharePermissionResource) Update(
+	ctx context.Context,
+	req resource.UpdateRequest,
+	resp *resource.UpdateResponse,
+) {
+	var plan SharePermissionResourceModel
+	resp.Diagnostics.Append(req.Plan.Get(ctx, &plan)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	if err := r.apply(ctx, plan); err != nil {
+		resp.Diagnostics.AddError("Failed to update share permissions", err.Error())
+		return
+	}
+	if err := r.refresh(ctx, &plan); err != nil {
+		resp.Diagnostics.AddError("Failed to read share permissions after update", err.Error())
+		return
+	}
+	resp.Diagnostics.Append(resp.State.Set(ctx, &plan)...)
+}
+
+func (r *SharePermissionResource) Delete(
+	ctx context.Context,
+	req resource.DeleteRequest,
+	resp *resource.DeleteResponse,
+) {
+	var state SharePermissionResourceModel
+	resp.Diagnostics.Append(req.State.Get(ctx, &state)...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	// Deleting the resource revokes every non-admin row it owned -- an
+	// empty declared set, applied the same way Update applies a shrunk one.
+	empty := SharePermissionResourceModel{
+		Share:         state.Share,
+		UserGroupType: state.UserGroupType,
+	}
+	if err := r.apply(ctx, empty); err != nil {
+		resp.Diagnostics.AddError("Failed to revoke share permissions", err.Error())
+	}
+}
+
+func (r *SharePermissionResource) ImportState(
+	ctx context.Context,
+	req resource.ImportStateRequest,
+	resp *resource.ImportStateResponse,
+) {
+	parts := strings.SplitN(req.ID, "/", 2)
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		resp.Diagnostics.AddError(
+			"Unexpected Import Identifier",
+			fmt.Sprintf(
+				"Expected import id in the form share/user_group_type, got: %q",
+				req.ID,
+			),
+		)
+		return
+	}
+	resp.Diagnostics.Append(resp.State.SetAttribute(ctx, path.Root("share"), parts[0])...)
+	resp.Diagnostics.Append(
+		resp.State.SetAttribute(ctx, path.Root("user_group_type"), parts[1])...)
+}

--- a/synology/provider/core/share_permission_resource.go
+++ b/synology/provider/core/share_permission_resource.go
@@ -23,6 +23,7 @@ import (
 var (
 	_ resource.Resource                = &SharePermissionResource{}
 	_ resource.ResourceWithImportState = &SharePermissionResource{}
+	_ resource.ResourceWithModifyPlan  = &SharePermissionResource{}
 )
 
 func NewSharePermissionResource() resource.Resource {
@@ -183,6 +184,117 @@ func (r *SharePermissionResource) Configure(
 		return
 	}
 	r.client = client.CoreAPI()
+}
+
+// ModifyPlan rebuilds the planned `permission` set directly from
+// configuration, overwriting whatever Terraform Core proposed for it.
+//
+// terraform-plugin-framework's schema.Default only fires when the *raw
+// config* value at a path is null (see TransformDefaults), and it locates
+// that raw config value by walking the plan's own tree and using each Set
+// element's *entire* object value as that element's identity -- Sets have no
+// other notion of "which element is this." Because is_readonly/is_writable/
+// is_deny/is_custom are all Optional+Computed, a row where the practitioner
+// sets any one of them away from its default no longer matches its
+// prior-state counterpart byte for byte, so Terraform Core's own
+// proposed-new-value computation (which runs *before* this provider is even
+// invoked, and which this method cannot see or influence) fails to correlate
+// the two: it treats the row as a brand-new element with no prior value.
+// Verified end-to-end against a real DSM (PLAT-705): a config declaring
+// `is_writable = true` for an existing row planned `is_writable = false` --
+// silently, with no diagnostic -- which would have revoked a real grant. A
+// row where every flag is left at its false default round-trips fine, which
+// is why the defect only shows up once a flag is set to true.
+//
+// Config is not subject to any of the above: Terraform always hands it over
+// intact, with no per-element correlation involved. So instead of trusting
+// the plan Core proposed, decode the row values straight from req.Config,
+// resolve the four settable flags' un-set (null) case to their documented
+// default of false ourselves, and write the corrected set into resp.Plan.
+func (r *SharePermissionResource) ModifyPlan(
+	ctx context.Context,
+	req resource.ModifyPlanRequest,
+	resp *resource.ModifyPlanResponse,
+) {
+	// Nothing to fix on a destroy plan: there is no new permission set.
+	if req.Plan.Raw.IsNull() {
+		return
+	}
+
+	var configPermission types.Set
+	resp.Diagnostics.Append(
+		req.Config.GetAttribute(ctx, path.Root("permission"), &configPermission)...,
+	)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+	if configPermission.IsNull() || configPermission.IsUnknown() {
+		return
+	}
+
+	var rows []sharePermissionEntryModel
+	if diags := configPermission.ElementsAs(ctx, &rows, false); diags.HasError() {
+		resp.Diagnostics.Append(diags...)
+		return
+	}
+
+	// is_admin is Computed-only: config can never supply it. Preserve it
+	// from prior state for a row that already exists there (that value came
+	// from DSM, not from this plan); a row with no prior-state counterpart
+	// is genuinely unknown until Create/Update runs and refresh() reads it
+	// back from DSM.
+	priorAdmin := map[string]types.Bool{}
+	if !req.State.Raw.IsNull() {
+		var statePermission types.Set
+		diags := req.State.GetAttribute(ctx, path.Root("permission"), &statePermission)
+		if !diags.HasError() && !statePermission.IsNull() && !statePermission.IsUnknown() {
+			var stateRows []sharePermissionEntryModel
+			if d := statePermission.ElementsAs(ctx, &stateRows, false); !d.HasError() {
+				for _, row := range stateRows {
+					priorAdmin[row.Name.ValueString()] = row.IsAdmin
+				}
+			}
+		}
+	}
+
+	objs := make([]attr.Value, 0, len(rows))
+	for _, row := range rows {
+		isAdmin, ok := priorAdmin[row.Name.ValueString()]
+		if !ok || isAdmin.IsNull() || isAdmin.IsUnknown() {
+			isAdmin = types.BoolUnknown()
+		}
+		obj, diags := types.ObjectValue(sharePermissionEntryAttrTypes(), map[string]attr.Value{
+			"name":        row.Name,
+			"is_readonly": boolOrFalse(row.IsReadonly),
+			"is_writable": boolOrFalse(row.IsWritable),
+			"is_deny":     boolOrFalse(row.IsDeny),
+			"is_custom":   boolOrFalse(row.IsCustom),
+			"is_admin":    isAdmin,
+		})
+		resp.Diagnostics.Append(diags...)
+		if resp.Diagnostics.HasError() {
+			return
+		}
+		objs = append(objs, obj)
+	}
+
+	set, diags := types.SetValue(types.ObjectType{AttrTypes: sharePermissionEntryAttrTypes()}, objs)
+	resp.Diagnostics.Append(diags...)
+	if resp.Diagnostics.HasError() {
+		return
+	}
+
+	resp.Diagnostics.Append(resp.Plan.SetAttribute(ctx, path.Root("permission"), set)...)
+}
+
+// boolOrFalse resolves a permission flag that may be null (unset in config)
+// to its documented schema default of false, leaving any concrete value
+// (including an explicit false) untouched.
+func boolOrFalse(v types.Bool) types.Bool {
+	if v.IsNull() {
+		return types.BoolValue(false)
+	}
+	return v
 }
 
 // planEntries decodes the plan's permission set into client entries, in a

--- a/synology/provider/core/share_permission_resource_modifyplan_test.go
+++ b/synology/provider/core/share_permission_resource_modifyplan_test.go
@@ -1,0 +1,321 @@
+package core
+
+import (
+	"context"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/attr"
+	"github.com/hashicorp/terraform-plugin-framework/path"
+	"github.com/hashicorp/terraform-plugin-framework/resource"
+	rschema "github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/tfsdk"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/hashicorp/terraform-plugin-go/tftypes"
+	"github.com/synology-community/go-synology/pkg/api/core"
+)
+
+// sharePermissionResourceSchemaForModifyPlanTest returns the resource's real
+// schema.Schema (not a hand-rolled stand-in), so the tftypes.Value built
+// below is exactly what Terraform would send over the wire.
+func sharePermissionResourceSchemaForModifyPlanTest(t *testing.T) rschema.Schema {
+	t.Helper()
+	resp := &resource.SchemaResponse{}
+	(&SharePermissionResource{}).Schema(context.Background(), resource.SchemaRequest{}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %s", resp.Diagnostics)
+	}
+	return resp.Schema
+}
+
+// permissionSetFromEntries builds a types.Set of types.Object -- constructed
+// directly with types.ObjectValue against the resource's own
+// sharePermissionEntryAttrTypes(), never through reflection over a Go
+// struct -- so it matches exactly what real config/state decodes to on the
+// wire. entries not listing a flag leave it null, the same as an unconfigured
+// attribute in real HCL.
+type permEntry struct {
+	name                                    string
+	readonly, writable, deny, custom, admin types.Bool
+}
+
+func permissionSetFromEntries(t *testing.T, entries []permEntry) types.Set {
+	t.Helper()
+	objs := make([]attr.Value, 0, len(entries))
+	for _, e := range entries {
+		obj, diags := types.ObjectValue(sharePermissionEntryAttrTypes(), map[string]attr.Value{
+			"name":        types.StringValue(e.name),
+			"is_readonly": e.readonly,
+			"is_writable": e.writable,
+			"is_deny":     e.deny,
+			"is_custom":   e.custom,
+			"is_admin":    e.admin,
+		})
+		if diags.HasError() {
+			t.Fatalf("ObjectValue(%s) diagnostics: %s", e.name, diags)
+		}
+		objs = append(objs, obj)
+	}
+	set, diags := types.SetValue(types.ObjectType{AttrTypes: sharePermissionEntryAttrTypes()}, objs)
+	if diags.HasError() {
+		t.Fatalf("SetValue diagnostics: %s", diags)
+	}
+	return set
+}
+
+// TestModifyPlan_PreservesConfiguredTrueFlag is the PLAT-705 regression
+// test. It reproduces the real end-to-end defect: a practitioner declares
+// `is_writable = true` for an account that already has that grant in state
+// (mirroring a `tofu import` followed by `tofu plan`), while Terraform
+// Core's own proposed plan -- which this test stands in for by deliberately
+// planning `is_writable = false`, the exact wrong value observed against a
+// real NAS -- cannot be trusted for Set-nested-block Computed attributes.
+// ModifyPlan must discard that proposal and rebuild the permission set from
+// req.Config, so the final plan -- and everything planEntries() derives
+// from it -- carries the practitioner's true value through untouched.
+//
+// A second row ("guest") pins the companion case from the bug report: an
+// all-null (unconfigured) row must still resolve every flag to its false
+// default, exactly as it did before this fix, so the correction does not
+// trade one class of dropped value for another.
+func TestModifyPlan_PreservesConfiguredTrueFlag(t *testing.T) {
+	ctx := context.Background()
+	sch := sharePermissionResourceSchemaForModifyPlanTest(t)
+
+	// Config: paatwood declares is_writable = true and leaves every other
+	// flag unconfigured (null); guest declares nothing at all (every flag
+	// null).
+	configPermission := permissionSetFromEntries(t, []permEntry{
+		{name: "paatwood", writable: types.BoolValue(true)},
+		{name: "guest"},
+	})
+	configModel := SharePermissionResourceModel{
+		Share:         types.StringValue("photo"),
+		UserGroupType: types.StringValue(core.ShareUserGroupTypeLocalUser),
+		Permission:    configPermission,
+	}
+	var configPlanForRaw tfsdk.Plan
+	configPlanForRaw.Schema = sch
+	if diags := configPlanForRaw.Set(ctx, &configModel); diags.HasError() {
+		t.Fatalf("building config raw value: %s", diags)
+	}
+	reqConfig := tfsdk.Config{Raw: configPlanForRaw.Raw, Schema: sch}
+
+	// Plan: stands in for Terraform Core's own (unreliable, for this
+	// schema shape) proposed value -- paatwood's is_writable planned false,
+	// the literal defect observed against a real NAS in PLAT-705.
+	planPermission := permissionSetFromEntries(t, []permEntry{
+		{
+			name:     "paatwood",
+			readonly: types.BoolValue(false),
+			writable: types.BoolValue(false),
+			deny:     types.BoolValue(false),
+			custom:   types.BoolValue(false),
+			admin:    types.BoolValue(false),
+		},
+		{
+			name:     "guest",
+			readonly: types.BoolValue(false),
+			writable: types.BoolValue(false),
+			deny:     types.BoolValue(false),
+			custom:   types.BoolValue(false),
+			admin:    types.BoolValue(false),
+		},
+	})
+	planModel := SharePermissionResourceModel{
+		Share:         types.StringValue("photo"),
+		UserGroupType: types.StringValue(core.ShareUserGroupTypeLocalUser),
+		Permission:    planPermission,
+	}
+	var reqPlan tfsdk.Plan
+	reqPlan.Schema = sch
+	if diags := reqPlan.Set(ctx, &planModel); diags.HasError() {
+		t.Fatalf("building plan raw value: %s", diags)
+	}
+
+	// State: mirrors what `tofu import` would have populated -- paatwood
+	// genuinely has is_writable = true on the real share today.
+	statePermission := permissionSetFromEntries(t, []permEntry{
+		{
+			name:     "paatwood",
+			readonly: types.BoolValue(false),
+			writable: types.BoolValue(true),
+			deny:     types.BoolValue(false),
+			custom:   types.BoolValue(false),
+			admin:    types.BoolValue(false),
+		},
+		{
+			name:     "guest",
+			readonly: types.BoolValue(false),
+			writable: types.BoolValue(false),
+			deny:     types.BoolValue(false),
+			custom:   types.BoolValue(false),
+			admin:    types.BoolValue(false),
+		},
+	})
+	stateModel := SharePermissionResourceModel{
+		Share:         types.StringValue("photo"),
+		UserGroupType: types.StringValue(core.ShareUserGroupTypeLocalUser),
+		Permission:    statePermission,
+	}
+	var reqState tfsdk.State
+	reqState.Schema = sch
+	if diags := reqState.Set(ctx, &stateModel); diags.HasError() {
+		t.Fatalf("building state raw value: %s", diags)
+	}
+
+	r := &SharePermissionResource{}
+	req := resource.ModifyPlanRequest{
+		Config: reqConfig,
+		Plan:   reqPlan,
+		State:  reqState,
+	}
+	resp := &resource.ModifyPlanResponse{
+		Plan: reqPlan,
+	}
+
+	r.ModifyPlan(ctx, req, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("ModifyPlan() diagnostics: %s", resp.Diagnostics)
+	}
+
+	var correctedPermission types.Set
+	if diags := resp.Plan.GetAttribute(ctx, path.Root("permission"), &correctedPermission); diags.HasError() {
+		t.Fatalf("reading corrected permission from resp.Plan: %s", diags)
+	}
+
+	correctedModel := SharePermissionResourceModel{Permission: correctedPermission}
+	entries, err := r.planEntries(ctx, correctedModel)
+	if err != nil {
+		t.Fatalf("planEntries() error = %v", err)
+	}
+
+	byName := map[string]core.SharePermissionSetEntry{}
+	for _, e := range entries {
+		byName[e.Name] = e
+	}
+
+	paatwood, ok := byName["paatwood"]
+	if !ok {
+		t.Fatal("paatwood missing from corrected plan entries")
+	}
+	if !paatwood.IsWritable {
+		t.Errorf(
+			"paatwood.IsWritable = false after ModifyPlan, want true: the configured "+
+				"is_writable = true was dropped (entries=%+v)",
+			entries,
+		)
+	}
+	if paatwood.IsReadonly || paatwood.IsDeny || paatwood.IsCustom {
+		t.Errorf("paatwood unexpected flags true: %+v, want only IsWritable", paatwood)
+	}
+
+	guest, ok := byName["guest"]
+	if !ok {
+		t.Fatal("guest missing from corrected plan entries")
+	}
+	if guest.IsReadonly || guest.IsWritable || guest.IsDeny || guest.IsCustom {
+		t.Errorf("guest = %+v, want every flag false (unconfigured -> default)", guest)
+	}
+}
+
+// TestModifyPlan_AllFlagsRoundTrip pins is_readonly, is_deny and is_custom
+// alongside is_writable: PLAT-705 was found via is_writable, but the same
+// Set/Computed/Default interaction is not specific to any one flag, so each
+// must survive ModifyPlan when configured true.
+func TestModifyPlan_AllFlagsRoundTrip(t *testing.T) {
+	ctx := context.Background()
+	sch := sharePermissionResourceSchemaForModifyPlanTest(t)
+
+	cases := []struct {
+		name    string
+		configd permEntry
+	}{
+		{name: "is_readonly", configd: permEntry{name: "acct", readonly: types.BoolValue(true)}},
+		{name: "is_writable", configd: permEntry{name: "acct", writable: types.BoolValue(true)}},
+		{name: "is_deny", configd: permEntry{name: "acct", deny: types.BoolValue(true)}},
+		{name: "is_custom", configd: permEntry{name: "acct", custom: types.BoolValue(true)}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			configModel := SharePermissionResourceModel{
+				Share:         types.StringValue("photo"),
+				UserGroupType: types.StringValue(core.ShareUserGroupTypeLocalUser),
+				Permission:    permissionSetFromEntries(t, []permEntry{tc.configd}),
+			}
+			var configPlanForRaw tfsdk.Plan
+			configPlanForRaw.Schema = sch
+			if diags := configPlanForRaw.Set(ctx, &configModel); diags.HasError() {
+				t.Fatalf("building config raw value: %s", diags)
+			}
+			reqConfig := tfsdk.Config{Raw: configPlanForRaw.Raw, Schema: sch}
+
+			// Deliberately wrong stand-in for Core's proposal: every flag
+			// false, regardless of what config says.
+			wrongPermission := permissionSetFromEntries(t, []permEntry{
+				{
+					name:     "acct",
+					readonly: types.BoolValue(false),
+					writable: types.BoolValue(false),
+					deny:     types.BoolValue(false),
+					custom:   types.BoolValue(false),
+					admin:    types.BoolValue(false),
+				},
+			})
+			planModel := SharePermissionResourceModel{
+				Share:         types.StringValue("photo"),
+				UserGroupType: types.StringValue(core.ShareUserGroupTypeLocalUser),
+				Permission:    wrongPermission,
+			}
+			var reqPlan tfsdk.Plan
+			reqPlan.Schema = sch
+			if diags := reqPlan.Set(ctx, &planModel); diags.HasError() {
+				t.Fatalf("building plan raw value: %s", diags)
+			}
+
+			// No prior state: simulate Create, where ModifyPlan must not
+			// look up an is_admin value that does not exist yet.
+			reqState := tfsdk.State{
+				Schema: sch,
+				Raw:    tftypes.NewValue(sch.Type().TerraformType(ctx), nil),
+			}
+
+			r := &SharePermissionResource{}
+			req := resource.ModifyPlanRequest{Config: reqConfig, Plan: reqPlan, State: reqState}
+			resp := &resource.ModifyPlanResponse{Plan: reqPlan}
+
+			r.ModifyPlan(ctx, req, resp)
+			if resp.Diagnostics.HasError() {
+				t.Fatalf("ModifyPlan() diagnostics: %s", resp.Diagnostics)
+			}
+
+			var correctedPermission types.Set
+			if diags := resp.Plan.GetAttribute(ctx, path.Root("permission"), &correctedPermission); diags.HasError() {
+				t.Fatalf("reading corrected permission: %s", diags)
+			}
+			entries, err := r.planEntries(ctx, SharePermissionResourceModel{Permission: correctedPermission})
+			if err != nil {
+				t.Fatalf("planEntries() error = %v", err)
+			}
+			if len(entries) != 1 {
+				t.Fatalf("entries = %+v, want exactly 1", entries)
+			}
+
+			e := entries[0]
+			got := map[string]bool{
+				"is_readonly": e.IsReadonly,
+				"is_writable": e.IsWritable,
+				"is_deny":     e.IsDeny,
+				"is_custom":   e.IsCustom,
+			}
+			if !got[tc.name] {
+				t.Errorf("entries[0] = %+v, want %s = true", e, tc.name)
+			}
+			for flag, v := range got {
+				if flag != tc.name && v {
+					t.Errorf("entries[0] = %+v, want only %s true", e, tc.name)
+				}
+			}
+		})
+	}
+}

--- a/synology/provider/core/share_permission_resource_schema_test.go
+++ b/synology/provider/core/share_permission_resource_schema_test.go
@@ -1,0 +1,126 @@
+package core_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	fwresource "github.com/hashicorp/terraform-plugin-framework/resource"
+	"github.com/hashicorp/terraform-plugin-framework/resource/schema"
+	"github.com/hashicorp/terraform-plugin-framework/schema/validator"
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/synology-community/terraform-provider-synology/synology/provider/core"
+)
+
+func sharePermissionSchema(t *testing.T) schema.Schema {
+	t.Helper()
+	resp := &fwresource.SchemaResponse{}
+	core.NewSharePermissionResource().Schema(context.Background(), fwresource.SchemaRequest{}, resp)
+	if resp.Diagnostics.HasError() {
+		t.Fatalf("schema diagnostics: %v", resp.Diagnostics)
+	}
+	return resp.Schema
+}
+
+func TestSharePermissionSchema_ShareAndUserGroupTypeRequireReplace(t *testing.T) {
+	t.Parallel()
+	s := sharePermissionSchema(t)
+	for _, name := range []string{"share", "user_group_type"} {
+		if !requiresReplace(t, s, name) {
+			t.Errorf("attribute %q must RequiresReplace", name)
+		}
+	}
+}
+
+func TestSharePermissionSchema_UserGroupTypeIsRestrictedToTheTwoKnownValues(t *testing.T) {
+	t.Parallel()
+	s := sharePermissionSchema(t)
+	attr, ok := s.Attributes["user_group_type"].(schema.StringAttribute)
+	if !ok {
+		t.Fatal(`attribute "user_group_type" is not a StringAttribute`)
+	}
+	if len(attr.Validators) == 0 {
+		t.Fatal(`attribute "user_group_type" has no validators; it must be restricted to ` +
+			`"local_user"/"local_group" so a typo fails at plan time rather than as an ` +
+			`opaque DSM error`)
+	}
+
+	ctx := context.Background()
+	req := validator.StringRequest{ConfigValue: types.StringValue("bogus_value")}
+	for _, v := range attr.Validators {
+		resp := &validator.StringResponse{}
+		v.ValidateString(ctx, req, resp)
+		if !resp.Diagnostics.HasError() {
+			t.Errorf("validator %T accepted the bogus value %q", v, "bogus_value")
+		}
+	}
+}
+
+func TestSharePermissionSchema_PermissionBlockCoversDenyAndNoAccessSeparately(t *testing.T) {
+	t.Parallel()
+	s := sharePermissionSchema(t)
+	block, ok := s.Blocks["permission"].(schema.SetNestedBlock)
+	if !ok {
+		t.Fatal(`block "permission" is not a SetNestedBlock (order must not matter)`)
+	}
+
+	for _, name := range []string{"is_readonly", "is_writable", "is_deny", "is_custom"} {
+		attr, ok := block.NestedObject.Attributes[name].(schema.BoolAttribute)
+		if !ok {
+			t.Fatalf("permission attribute %q is not a BoolAttribute", name)
+		}
+		if !attr.Optional {
+			t.Errorf("permission attribute %q must be Optional (settable from config)", name)
+		}
+	}
+}
+
+func TestSharePermissionSchema_IsAdminIsComputedOnlyNeverConfigurable(t *testing.T) {
+	t.Parallel()
+	s := sharePermissionSchema(t)
+	block, ok := s.Blocks["permission"].(schema.SetNestedBlock)
+	if !ok {
+		t.Fatal(`block "permission" is not a SetNestedBlock`)
+	}
+	attr, ok := block.NestedObject.Attributes["is_admin"].(schema.BoolAttribute)
+	if !ok {
+		t.Fatal(`permission attribute "is_admin" is not a BoolAttribute`)
+	}
+	if !attr.Computed {
+		t.Error(`"is_admin" must be Computed: it reflects DSM's admin-group flag, not a grant`)
+	}
+	if attr.Optional || attr.Required {
+		t.Error(`"is_admin" must not be Optional or Required: config must never set it`)
+	}
+}
+
+func TestSharePermissionSchema_NameAttributeIsRequired(t *testing.T) {
+	t.Parallel()
+	s := sharePermissionSchema(t)
+	block, ok := s.Blocks["permission"].(schema.SetNestedBlock)
+	if !ok {
+		t.Fatal(`block "permission" is not a SetNestedBlock`)
+	}
+	attr, ok := block.NestedObject.Attributes["name"].(schema.StringAttribute)
+	if !ok {
+		t.Fatal(`permission attribute "name" is not a StringAttribute`)
+	}
+	if !attr.Required {
+		t.Error(`permission attribute "name" must be Required`)
+	}
+}
+
+// TestSharePermissionSchema_DocumentsAdministratorsAndFullOwnership pins the
+// two behaviours a practitioner cannot discover from the plan alone: the
+// administrators group can never be managed here, and this resource owns
+// (and will delete) the entire remote list for its (share, user_group_type).
+func TestSharePermissionSchema_DocumentsAdministratorsAndFullOwnership(t *testing.T) {
+	t.Parallel()
+	s := sharePermissionSchema(t)
+	doc := strings.ToLower(s.MarkdownDescription)
+	for _, want := range []string{"administrators", "full ownership", "firewall_profile"} {
+		if !strings.Contains(doc, want) {
+			t.Errorf("schema description does not mention %q", want)
+		}
+	}
+}

--- a/synology/provider/core/share_permission_resource_test.go
+++ b/synology/provider/core/share_permission_resource_test.go
@@ -1,0 +1,286 @@
+package core
+
+import (
+	"context"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-framework/types"
+	"github.com/synology-community/go-synology/pkg/api/core"
+)
+
+// stubSharePermissionAPI implements core.Api by embedding it (nil) and
+// overriding only SharePermissionList/SharePermissionSet -- the two methods
+// SharePermissionResource's apply()/refresh() paths reach. Any other method
+// call would nil-pointer-panic; that's intentional (see stubTaskUpdateAPI in
+// task_update_state_test.go for the precedent this follows).
+type stubSharePermissionAPI struct {
+	core.Api
+	current []core.SharePermission
+	// sets records every call SharePermissionSet receives, in order, so
+	// tests can assert exactly what was sent to DSM.
+	sets [][]core.SharePermissionSetEntry
+}
+
+func (s *stubSharePermissionAPI) SharePermissionList(
+	_ context.Context,
+	_ string,
+	_ string,
+) (*core.SharePermissionListResponse, error) {
+	items := make([]core.SharePermission, len(s.current))
+	copy(items, s.current)
+	return &core.SharePermissionListResponse{Items: items}, nil
+}
+
+func (s *stubSharePermissionAPI) SharePermissionSet(
+	_ context.Context,
+	_ string,
+	_ string,
+	perms []core.SharePermissionSetEntry,
+) error {
+	cp := make([]core.SharePermissionSetEntry, len(perms))
+	copy(cp, perms)
+	s.sets = append(s.sets, cp)
+
+	// Apply the write onto `current` so a subsequent SharePermissionList
+	// reflects it, the same way DSM would -- SharePermissionSetEntry has no
+	// IsAdmin field, so a row's admin flag is preserved untouched across a
+	// Set the way DSM's real behaviour is documented to work.
+	byName := map[string]core.SharePermission{}
+	for _, item := range s.current {
+		byName[item.Name] = item
+	}
+	for _, e := range perms {
+		prior := byName[e.Name]
+		byName[e.Name] = core.SharePermission{
+			Name:       e.Name,
+			IsAdmin:    prior.IsAdmin,
+			IsCustom:   e.IsCustom,
+			IsDeny:     e.IsDeny,
+			IsReadonly: e.IsReadonly,
+			IsWritable: e.IsWritable,
+		}
+	}
+	items := make([]core.SharePermission, 0, len(byName))
+	for _, v := range byName {
+		items = append(items, v)
+	}
+	sort.Slice(items, func(i, j int) bool { return items[i].Name < items[j].Name })
+	s.current = items
+	return nil
+}
+
+func newSharePermissionModel(
+	t *testing.T,
+	share, userGroupType string,
+	rows []sharePermissionEntryModel,
+) SharePermissionResourceModel {
+	t.Helper()
+	set, diags := types.SetValueFrom(
+		context.Background(),
+		types.ObjectType{AttrTypes: sharePermissionEntryAttrTypes()},
+		rows,
+	)
+	if diags.HasError() {
+		t.Fatalf("SetValueFrom() diagnostics: %s", diags)
+	}
+	return SharePermissionResourceModel{
+		Share:         types.StringValue(share),
+		UserGroupType: types.StringValue(userGroupType),
+		Permission:    set,
+	}
+}
+
+// TestApply_RejectsAdminDeclaredEntries is the PLAT-705 guardrail: the
+// administrators group always has read/write on every share and DSM offers
+// no way to revoke it, so declaring a permission block for an
+// administrator-flagged account must fail the plan rather than send a Set
+// call DSM will silently no-op or that plans a change that can never
+// converge.
+func TestApply_RejectsAdminDeclaredEntries(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubSharePermissionAPI{
+		current: []core.SharePermission{
+			{Name: "administrators", IsAdmin: true, IsReadonly: false, IsWritable: true},
+		},
+	}
+	r := &SharePermissionResource{client: stub}
+
+	plan := newSharePermissionModel(t, "myshare", core.ShareUserGroupTypeLocalGroup, []sharePermissionEntryModel{
+		{
+			Name:       types.StringValue("administrators"),
+			IsReadonly: types.BoolValue(false),
+			IsWritable: types.BoolValue(true),
+			IsDeny:     types.BoolValue(false),
+			IsCustom:   types.BoolValue(false),
+			IsAdmin:    types.BoolValue(true),
+		},
+	})
+
+	err := r.apply(ctx, plan)
+	if err == nil {
+		t.Fatal("apply() error = nil, want an error rejecting the administrators block")
+	}
+	if !strings.Contains(err.Error(), "administrators") {
+		t.Errorf("apply() error = %q, want it to name the rejected account", err.Error())
+	}
+	if len(stub.sets) != 0 {
+		t.Errorf("SharePermissionSet was called %d time(s), want 0: a rejected plan must not "+
+			"reach DSM", len(stub.sets))
+	}
+}
+
+// TestApply_RevokesRowsAbsentFromConfig pins full-list ownership: a row that
+// exists remotely but is not declared in config must be sent back to DSM
+// with every flag false (no access), not merely left alone. Otherwise
+// out-of-band grants would survive every apply, which is the exact "fight
+// other tooling" tradeoff this resource is documented to resolve by owning
+// the whole list.
+func TestApply_RevokesRowsAbsentFromConfig(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubSharePermissionAPI{
+		current: []core.SharePermission{
+			{Name: "administrators", IsAdmin: true, IsWritable: true},
+			{Name: "alice", IsWritable: true},
+			{Name: "bob", IsReadonly: true},
+		},
+	}
+	r := &SharePermissionResource{client: stub}
+
+	// Config declares only alice; bob was granted out-of-band.
+	plan := newSharePermissionModel(t, "myshare", core.ShareUserGroupTypeLocalUser, []sharePermissionEntryModel{
+		{
+			Name:       types.StringValue("alice"),
+			IsReadonly: types.BoolValue(false),
+			IsWritable: types.BoolValue(true),
+			IsDeny:     types.BoolValue(false),
+			IsCustom:   types.BoolValue(false),
+		},
+	})
+
+	if err := r.apply(ctx, plan); err != nil {
+		t.Fatalf("apply() error = %v", err)
+	}
+	if len(stub.sets) != 1 {
+		t.Fatalf("SharePermissionSet called %d time(s), want 1", len(stub.sets))
+	}
+
+	byName := map[string]core.SharePermissionSetEntry{}
+	for _, e := range stub.sets[0] {
+		byName[e.Name] = e
+	}
+
+	if _, ok := byName["administrators"]; ok {
+		t.Error("SharePermissionSet was sent an administrators row; it must never be touched")
+	}
+	alice, ok := byName["alice"]
+	if !ok || !alice.IsWritable {
+		t.Errorf("alice entry = %+v, ok=%v; want a writable entry preserved from config", alice, ok)
+	}
+	bob, ok := byName["bob"]
+	if !ok {
+		t.Fatal("bob (undeclared, out-of-band) was not sent a revoke entry")
+	}
+	if bob.IsReadonly || bob.IsWritable || bob.IsDeny || bob.IsCustom {
+		t.Errorf("bob revoke entry = %+v, want every flag false (no access)", bob)
+	}
+}
+
+// TestRefresh_ExcludesAdminRows guards the read side of the same PLAT-705
+// constraint: an administrator-flagged row must never enter state, or every
+// subsequent plan would show Terraform wanting to delete a block config
+// never declared (state has it, config doesn't -- a permanent diff).
+func TestRefresh_ExcludesAdminRows(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubSharePermissionAPI{
+		current: []core.SharePermission{
+			{Name: "administrators", IsAdmin: true, IsWritable: true},
+			{Name: "alice", IsWritable: true},
+		},
+	}
+	r := &SharePermissionResource{client: stub}
+
+	data := SharePermissionResourceModel{
+		Share:         types.StringValue("myshare"),
+		UserGroupType: types.StringValue(core.ShareUserGroupTypeLocalUser),
+	}
+	if err := r.refresh(ctx, &data); err != nil {
+		t.Fatalf("refresh() error = %v", err)
+	}
+
+	var rows []sharePermissionEntryModel
+	if diags := data.Permission.ElementsAs(ctx, &rows, false); diags.HasError() {
+		t.Fatalf("ElementsAs() diagnostics: %s", diags)
+	}
+	if len(rows) != 1 || rows[0].Name.ValueString() != "alice" {
+		t.Errorf("refreshed permission rows = %+v, want exactly [alice]", rows)
+	}
+}
+
+// TestRefresh_RoundTripsDenyDistinctFromNoAccess pins schema constraint 3:
+// is_deny=true is a different state than every flag false, and refresh()
+// must preserve that distinction rather than collapsing it.
+func TestRefresh_RoundTripsDenyDistinctFromNoAccess(t *testing.T) {
+	ctx := context.Background()
+	stub := &stubSharePermissionAPI{
+		current: []core.SharePermission{
+			{Name: "denied-user", IsDeny: true},
+			{Name: "no-access-user"},
+		},
+	}
+	r := &SharePermissionResource{client: stub}
+
+	data := SharePermissionResourceModel{
+		Share:         types.StringValue("myshare"),
+		UserGroupType: types.StringValue(core.ShareUserGroupTypeLocalUser),
+	}
+	if err := r.refresh(ctx, &data); err != nil {
+		t.Fatalf("refresh() error = %v", err)
+	}
+
+	var rows []sharePermissionEntryModel
+	if diags := data.Permission.ElementsAs(ctx, &rows, false); diags.HasError() {
+		t.Fatalf("ElementsAs() diagnostics: %s", diags)
+	}
+	byName := map[string]sharePermissionEntryModel{}
+	for _, row := range rows {
+		byName[row.Name.ValueString()] = row
+	}
+
+	denied, ok := byName["denied-user"]
+	if !ok || !denied.IsDeny.ValueBool() {
+		t.Errorf("denied-user = %+v, ok=%v; want is_deny=true", denied, ok)
+	}
+	noAccess, ok := byName["no-access-user"]
+	if !ok {
+		t.Fatal("no-access-user missing from refreshed state")
+	}
+	if noAccess.IsDeny.ValueBool() || noAccess.IsReadonly.ValueBool() ||
+		noAccess.IsWritable.ValueBool() {
+		t.Errorf("no-access-user = %+v, want every flag false (distinct from an explicit deny)",
+			noAccess)
+	}
+}
+
+// TestPlanEntries_SortsByName pins the stable-ordering contract planEntries
+// documents: successive applies of the same config must produce the same
+// SharePermissionSet payload order, or every plan would show a spurious diff
+// from set-element reordering alone.
+func TestPlanEntries_SortsByName(t *testing.T) {
+	ctx := context.Background()
+	r := &SharePermissionResource{}
+
+	plan := newSharePermissionModel(t, "myshare", core.ShareUserGroupTypeLocalUser, []sharePermissionEntryModel{
+		{Name: types.StringValue("zed"), IsReadonly: types.BoolValue(true)},
+		{Name: types.StringValue("alice"), IsWritable: types.BoolValue(true)},
+	})
+
+	entries, err := r.planEntries(ctx, plan)
+	if err != nil {
+		t.Fatalf("planEntries() error = %v", err)
+	}
+	if len(entries) != 2 || entries[0].Name != "alice" || entries[1].Name != "zed" {
+		t.Errorf("planEntries() = %+v, want [alice, zed] in that order", entries)
+	}
+}


### PR DESCRIPTION
## Why

Manages the complete `SYNO.Core.Share.Permission` list for one `(share, user_group_type)` pair.

**Depends on** the companion go-synology PR that adds `SharePermissionList` / `SharePermissionSet` via a `SYNO.Entry.Request` compound envelope. This branch does **not** bump `go.mod` to a private fork; until that client PR merges, this package will not compile against community `go-synology` `main`. That sequencing is intentional.

Also includes the `ModifyPlan` fix: Terraform Core's `SetNestedBlock` correlation silently zeros `is_writable = true` (and the other three settable flags) when any flag leaves its default. `ModifyPlan` rebuilds the planned set from `req.Config`.

`administrators` (DSM `is_admin`) is excluded from state and refused in config — DSM grants that group RW on every share with no way to revoke it.

Acceptance tests run against production hardware in our fork (`TestAccSharePermissionResource`) and are not in this PR: they depend on `synology_core_user` / `synology_core_share`, which are not on community `main` yet.

Offered per FCG ADR-0010.

## Test plan

- [x] Offline schema + whitebox + ModifyPlan tests (in this diff)
- [x] Live acc tests on the fork (TMAtwood/terraform-provider-synology#7)
- [ ] Compile against community go-synology after the client PR merges

Refs: https://tmatwood.atlassian.net/browse/PLAT-741