### PR TITLE
fix: do not panic TestMain when virtual DSM is unhealthy

### DIFF
--- a/synology/provider/provider_test.go
+++ b/synology/provider/provider_test.go
@@ -69,11 +69,22 @@ func runAcceptanceTests(m *testing.M) int {
 	// The health check may have a long start_period which can cause timeouts in testcontainers
 	if err = dc.WithOsEnv().
 		Up(ctx, testcompose.Wait(true), testcompose.WithRecreate(api.RecreateDiverged)); err != nil {
-		// Community CI sets TF_ACC=1 on every PR. Fork runs have no virtual-DSM
-		// image and no NAS secrets; compose then reports dsm-test unhealthy and
-		// a panic here fails the whole `go test ./...` job. Individual TestAcc*
-		// cases skip via TestAccPreCheck when SYNOLOGY_* are unset.
+		// Community CI sets TF_ACC=1 on every PR. Compose then reports
+		// dsm-test unhealthy and a panic here used to fail the whole
+		// `go test ./...` job. Tear down whatever compose created, and
+		// drop SYNOLOGY_* so TestAccPreCheck skips instead of aiming
+		// remaining acceptance tests at a workflow-secret NAS.
 		fmt.Fprintf(os.Stderr, "virtual DSM compose up failed: %v; running without it\n", err)
+		if downErr := dc.Down(
+			context.Background(),
+			testcompose.RemoveOrphans(true),
+			testcompose.RemoveImagesLocal,
+		); downErr != nil {
+			fmt.Fprintf(os.Stderr, "virtual DSM compose down failed: %v\n", downErr)
+		}
+		for _, k := range []string{"SYNOLOGY_HOST", "SYNOLOGY_USER", "SYNOLOGY_PASSWORD"} {
+			_ = os.Unsetenv(k)
+		}
 		return m.Run()
 	}
 

--- a/synology/provider/provider_test.go
+++ b/synology/provider/provider_test.go
@@ -69,7 +69,12 @@ func runAcceptanceTests(m *testing.M) int {
 	// The health check may have a long start_period which can cause timeouts in testcontainers
 	if err = dc.WithOsEnv().
 		Up(ctx, testcompose.Wait(true), testcompose.WithRecreate(api.RecreateDiverged)); err != nil {
-		panic(err)
+		// Community CI sets TF_ACC=1 on every PR. Fork runs have no virtual-DSM
+		// image and no NAS secrets; compose then reports dsm-test unhealthy and
+		// a panic here fails the whole `go test ./...` job. Individual TestAcc*
+		// cases skip via TestAccPreCheck when SYNOLOGY_* are unset.
+		fmt.Fprintf(os.Stderr, "virtual DSM compose up failed: %v; running without it\n", err)
+		return m.Run()
 	}
 
 	defer func() {

--- a/synology/provider/virtualization/image_resource.go
+++ b/synology/provider/virtualization/image_resource.go
@@ -469,7 +469,10 @@ func (f *ImageResource) getImage(ctx context.Context, name string) (*virtualizat
 // getImageByID looks up an image by its unique ID rather than its name.
 // Unlike Name, ID never collides between a deposed instance and its live
 // replacement, so Read/Delete must use this instead of getImage.
-func (f *ImageResource) getImageByID(ctx context.Context, id string) (*virtualization.Image, error) {
+func (f *ImageResource) getImageByID(
+	ctx context.Context,
+	id string,
+) (*virtualization.Image, error) {
 	images, err := f.client.ImageList(ctx)
 	if err != nil {
 		return nil, err

--- a/synology/util/iso.go
+++ b/synology/util/iso.go
@@ -75,7 +75,10 @@ func IsoFromCloudInit(ctx context.Context, ci CloudInit) ([]byte, error) {
 		// Blindly prepending "#cloud-config" to an already-multipart document
 		// corrupts it: cloud-init then reads the whole MIME envelope as one
 		// YAML doc and silently skips user-data processing entirely.
-		if match, _ := regexp.MatchString(`(?i)^(#cloud-config|content-type:|mime-version:)`, ci.UserData); !match {
+		if match, _ := regexp.MatchString(
+			`(?i)^(#cloud-config|content-type:|mime-version:)`,
+			ci.UserData,
+		); !match {
 			ci.UserData = fmt.Sprintf("#cloud-config\n%s", ci.UserData)
 		}
 


### PR DESCRIPTION
## Summary

Follow-up to #218. Community CI always sets `TF_ACC=1`, so `TestMain` always runs `docker compose up`. On fork PRs (and on GitHub-hosted runners without a healthy `dsm-test`) that compose fails with `container dsm-test is unhealthy` and **panics**, which fails the whole `go test ./...` job even after #218 taught `TestAcc*` to skip when `SYNOLOGY_*` are unset.

This replaces that panic with a stderr line and `m.Run()`, so unit tests still run. Live cases keep skipping via `TestAccPreCheck`.

## Test plan

- [x] `TF_ACC=1 go test ./synology/provider/ -run 'TestAccProvider|TestBuildISO'` exits 0 without a healthy DSM (compose failure is printed, suite continues)
- [ ] GitHub Actions `test` on this PR does not panic in `TestMain`

Refs #218